### PR TITLE
CHA-27 added hook for fetching data, organized toolbar

### DIFF
--- a/frontend/src/UnauthenticatedApp.js
+++ b/frontend/src/UnauthenticatedApp.js
@@ -1,13 +1,5 @@
 import React from 'react';
-import { Grid } from '@material-ui/core'
-
 import LoginPanel from './components/login/LoginPanel'
-
-import {
-    BrowserRouter as Router,
-    Switch,
-    Route
-} from "react-router-dom";
 
 
 const UnauthenticatedApp = () => {

--- a/frontend/src/components/Admin/AddNewUserPanel.js
+++ b/frontend/src/components/Admin/AddNewUserPanel.js
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 import { useState } from 'react'
 import { makeStyles } from '@material-ui/core/styles';
 import InputLabel from '@material-ui/core/InputLabel';
@@ -9,8 +9,7 @@ import { Button, Card, CardContent, CardHeader, MenuItem, Select, Typography } f
 import PageTitle from '../PageTitle/PageTitle'
 
 import { useAuthState } from '../../context/AuthContext'
-
-
+import useFetch from '../../hooks/useFetch'
 
 const useStyles = makeStyles((theme) => ({
     margin: {
@@ -36,26 +35,9 @@ export default function AddNewUserPanel() {
 
     const [userCreated, setUserCreated] = useState(null)
 
-    const [faculties, setFaculties] = useState([])
 
-    useEffect(() => {
-        fetch('api/backend/faculties', {
-            method: "GET",
-            headers: {
-                'Content-Type': 'application/json',
-                'Authorization': `Bearer ${authState.access}`,
-            },
-        })
-            .then(response => {
-                //TODO lepiej obsługiwać błędy
-                if(response.ok) return response.json()
-                else throw new Error(response.status)
-            })
-            .then(json => {
-                setFaculties(json)
-            })
-            .catch(e => console.log(e))
-    }, [])
+    const [faculties, loading, error] = useFetch('api/backend/faculties', [])
+
 
     const classes = useStyles();
 
@@ -90,7 +72,7 @@ export default function AddNewUserPanel() {
         event.preventDefault()
         if (validateInput()) {
 
-            const body = { ...newUserData, faculty: null } // TODO usunąć to bo to jest hack na prezentację i powinno być zdelegalizowane
+            const body = { ...newUserData } 
             body.is_staff = newUserData.is_staff === 'admin' ? true : false
 
             console.log(authState.access)

--- a/frontend/src/components/Header/Header.js
+++ b/frontend/src/components/Header/Header.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { AppBar, IconButton, Toolbar, Typography } from '@material-ui/core'
+import { AppBar, Grid, IconButton, Toolbar, Typography } from '@material-ui/core'
 import { ReactComponent as Logo } from '../../static/logo/logo.svg'
 // import HeaderDropdownMenu from './HeaderDropdownMenu'
 import { useAuthDispatch } from '../../context/AuthContext.js';
@@ -30,48 +30,51 @@ const Header = () => {
 
     return (
         <AppBar position='fixed' className={classes.appBar}>
-            <Toolbar className={classes.toolBar}>
-                <IconButton
-                    color="inherit"
-                    onClick={() => sidebarToggle(!sidebarState)}
-                    className={classNames(
-                        classes.headerMenuButtonSandwich,
-                        classes.headerMenuButtonSandwich
-                    )}
-                >
-                    {
-                        sidebarState ?
-                            <ArrowBackIcon classes={{
+            <Toolbar >
+                <Grid container spacing={2}>
+                    <Grid item  container xs={4} >
+                        <IconButton
+                            color="inherit"
+                            onClick={() => sidebarToggle(!sidebarState)}
+                        >
+                            {
+                                sidebarState ?
+                                    <ArrowBackIcon classes={{
+                                        root: classNames(
+                                            classes.headerIcon
+                                        )
+                                    }} />
+                                    :
+                                    <MenuIcon classes={{
+                                        root: classNames(
+                                            classes.headerIcon
+                                        )
+                                    }} />
+
+                            }
+                        </IconButton>
+                        <Link to='/' className={classes.logo}>
+                            <Logo />
+                        </Link>
+                    </Grid>
+
+                    <Grid item container xs={4} alignContent='center' justify='center'>
+                        <Typography variant='h3' >Rekrutacja AGH</Typography>
+                    </Grid>
+                    <Grid item container xs={4} aligntContent='right' justify='flex-end'>
+                        <IconButton
+                            color="inherit"
+                            onClick={() => logoutUser(dispatch)}
+
+                        >
+                            <ExitToAppIcon classes={{
                                 root: classNames(
                                     classes.headerIcon
                                 )
                             }} />
-                            :
-                            <MenuIcon classes={{
-                                root: classNames(
-                                    classes.headerIcon
-                                )
-                            }} />
-
-                    }
-                </IconButton>
-                <Link to='/' className={classes.logo}>
-                    <Logo />
-                </Link>
-                <div classNames={classes.grow}></div>
-                <Typography className={classes.title} variant='h3' >Rekrutacja AGH</Typography>
-
-                <IconButton
-                    color="inherit"
-                    onClick={() => logoutUser(dispatch)}
-                    classes={{
-                        root: classNames(
-                            classes.headerIcon
-                        )
-                    }}
-                >
-                    <ExitToAppIcon />
-                </IconButton>
+                        </IconButton>
+                    </Grid>
+                </Grid>
             </Toolbar>
         </AppBar>
     )

--- a/frontend/src/components/Header/styles.js
+++ b/frontend/src/components/Header/styles.js
@@ -1,18 +1,5 @@
 import { makeStyles } from "@material-ui/styles";
 
-// const useStyles = makeStyles({
-//     toolbar: {
-//         background: 'primary',
-//         minHeight: '100px',
-//         textAlign: 'center'
-//     },
-//     logo: {
-//         marginLeft: '10%'
-//     },
-//     title: {
-//         marginLeft: '30%'
-//     }
-// })
 
 export default makeStyles(theme => ({
     logo: {
@@ -22,23 +9,6 @@ export default makeStyles(theme => ({
     appBar: {
         width: "100vw",
         zIndex: theme.zIndex.drawer + 1,
-    },
-    title: {
-        marginLeft: theme.spacing(50)
-    },
-    grow: {
-        flexGrow: 1,
-    },
-    toolbar: {
-        paddingLeft: theme.spacing(2),
-        paddingRight: theme.spacing(2),
-    },
-    hide: {
-        display: "none",
-    },
-    headerMenuButton: {
-        marginLeft: theme.spacing(2),
-        padding: theme.spacing(0.5),
     },
     headerIcon: {
         fontSize: 35,

--- a/frontend/src/components/Sidebar/Sidebar.js
+++ b/frontend/src/components/Sidebar/Sidebar.js
@@ -18,16 +18,6 @@ import classNames from 'classnames'
 import useStyles from './styles'
 import { useAuthState } from '../../context/AuthContext'
 
-const links = [
-    { id: 0, label: "Dashboard", link: '/', icon: <HomeIcon /> },
-    { id: 1, label: "Dodaj dane", link: '/dodajDane', icon: <AddBoxIcon /> },
-    { id: 2, label: "Podsumowanie", link: '/podsumowanie', icon: <TableChartIcon /> },
-    { id: 3, label: "Dodaj użytkownika", link: '/rejestracja', icon: <PersonAddIcon /> },
-]
-
-
-
-
 
 const Sidebar = ({location}) => {
     const classes = useStyles()
@@ -35,13 +25,20 @@ const Sidebar = ({location}) => {
     const sidebarState = useLayoutState()
     const authState = useAuthState()
 
-    const links = [
+    var links = [
         { id: 0, label: "Dashboard", link: '/', icon: <HomeIcon /> },
         { id: 1, label: "Dodaj dane", link: '/dodajDane', icon: <AddBoxIcon /> },
         { id: 2, label: "Podsumowanie", link: '/podsumowanie', icon: <TableChartIcon /> },
-        authState.is_staff && { id: 3, label: "Dodaj użytkownika", link: '/rejestracja', icon: <PersonAddIcon /> },
+    ]
+
+    const adminLinks = [
+        { id: 3, label: "Dodaj użytkownika", link: '/rejestracja', icon: <PersonAddIcon /> },
     ]
     
+    if (authState.is_staff){
+        links = links.concat(adminLinks)
+    }
+      
 
     return (
         <Drawer
@@ -72,15 +69,10 @@ const Sidebar = ({location}) => {
                             location={location}
                         />
                     ))
-
-
                 }
             </List>
-
         </Drawer>
-
     )
-
 }
 
 

--- a/frontend/src/hooks/useFetch.js
+++ b/frontend/src/hooks/useFetch.js
@@ -1,0 +1,44 @@
+import { useState } from 'react'
+import { useEffect } from 'react'
+
+import { useAuthState } from '../context/AuthContext'
+
+/*
+Hook for fetching data with GET method. It indicated if request has finished and if there were some errors
+
+@param url - url of resource to fetch
+@param initialState - {} for objects or [] for arrays
+
+@returns array with fetch data, loading indicator, error indicator
+
+*/
+const useFetch = (url, initialState) => {
+    const [data, setData] = useState(initialState)
+    const [isLoading, setIsLoading] = useState(true)
+    const [hasError, setHasError] = useState(false)
+
+    const authState = useAuthState()
+
+    useEffect(() => {
+        fetch(url, {
+            headers: {
+                'Content-Type': 'application/json',
+                'Authorization': `Bearer ${authState.access}`,
+            }
+        }).then(response => {
+            setIsLoading(false)
+            if (response.ok) return response.json()
+            else {
+                setHasError(true)
+                throw new Error(`Response code is ${response.status}`)
+            }
+        }).then(json => setData(json))
+        .catch(e => console.log(e))
+
+    }, [url])
+
+
+    return [data, isLoading, hasError]
+}
+
+export default useFetch

--- a/frontend/src/pages/AddData/AddDataPanel.js
+++ b/frontend/src/pages/AddData/AddDataPanel.js
@@ -1,9 +1,9 @@
 import React from 'react';
 import { useState } from 'react'
 import { makeStyles } from '@material-ui/core/styles';
-import { DatePicker, MuiPickersUtilsProvider } from '@material-ui/pickers';
+import { MuiPickersUtilsProvider } from '@material-ui/pickers';
 import Grid from '@material-ui/core/Grid';
-import { Button, Card, CardContent, CardHeader, Typography, FormControl, Select, MenuItem, InputLabel } from '@material-ui/core';
+import { Button, Card, CardContent, CardHeader, Typography } from '@material-ui/core';
 import MomentUtils from '@date-io/moment';
 import PageTitle from '../../components/PageTitle/PageTitle';
 import { useAuthState } from '../../context/AuthContext'
@@ -14,8 +14,6 @@ const useStyles = makeStyles((theme) => ({
         margin: theme.spacing(1),
     },
 }));
-
-const cycles = [1, 2, 3, 4, 5, 6]
 
 
 const AddDataPanel = () => {

--- a/frontend/src/pages/TableRaport/TableRaportPanel.js
+++ b/frontend/src/pages/TableRaport/TableRaportPanel.js
@@ -9,6 +9,7 @@ import FormControl from '@material-ui/core/FormControl';
 import { Button, Card, CardContent, Grid, MenuItem, Select } from '@material-ui/core';
 
 import { options, columns } from './tableConfig'
+import useFetch from '../../hooks/useFetch'
 
 const initialFormState = {
     cycle: 1,
@@ -61,31 +62,7 @@ const TableRaportPanel = () => {
     const [data, setData] = React.useState([])
     const authState = useAuthState()
 
-    const [faculties, setFaculties] = React.useState([])
-
-    React.useEffect(() => {
-        fetch('api/backend/faculties', {
-            method: "GET",
-            headers: {
-                'Content-Type': 'application/json',
-                'Authorization': `Bearer ${authState.access}`,
-            },
-        })
-            .then(response => {
-                if (response.ok) {
-                    console.log("ok")
-                    return response.json()
-                }
-                else throw new Error("nie")
-            })
-            .then(json => {
-                console.log(json)
-                setFaculties(json)
-            }
-            )
-            .catch(e => console.log(e))
-    }, [])
-
+    const [faculties, loading, error] = useFetch('api/backend/faculties', [])
 
     const handleInputChange = (e, type) => {
         e.preventDefault()


### PR DESCRIPTION
Trochę ogarnąłem toolbar, dodałem hooka useFetch, który pozwala łatwo dostawać dane przez GET, potrzebne do wyświetlania danych. Użycie to:
```
const [data, loading, error] = useFetch(url, [])
```
gdzie data, to dane, które chcemy uzyskać, lub drugi argument wywołania (na początku, albo jeśli coś się nie uda), loading to wskaźnik, czy coś się ładuje (można wyrenderować w tym czasie jakiś spinner), error wskazuje, czy udało się wykonać fetcha. 
Argumenty wywołania to: url - adres z pod którego dane są pobierane, initial state, czyli defecato [] jeśli chcemy pobrać tablicę i {} jeśli chcemy pobrać obiekt