### PR TITLE
CHA-40 implemented laureates count endpoint

### DIFF
--- a/backend/models.py
+++ b/backend/models.py
@@ -42,6 +42,7 @@ class Candidate(models.Model):
     gender = models.CharField(max_length=50)
     year_of_exam = models.IntegerField()
     city = models.CharField(max_length=80)
+    contest = models.CharField(max_length=80, null=True)
 
 
 class GraduatedSchool(models.Model):

--- a/backend/urls.py
+++ b/backend/urls.py
@@ -1,9 +1,7 @@
 from django.urls import path, re_path
 
 from .views import (FieldOfStudyContestLaureatesCountView, GetFacultiesView,
-                    GetFieldsOfStudy, RecruitmentResultListView)
-from .views import (GetFacultiesView, GetFieldsOfStudy,
-                    RecruitmentResultFacultiesListView,
+                    GetFieldsOfStudy, RecruitmentResultFacultiesListView,
                     RecruitmentResultFieldsOfStudyListView,
                     RecruitmentResultListView,
                     RecruitmentResultOverviewListView, UploadView)

--- a/backend/urls.py
+++ b/backend/urls.py
@@ -1,7 +1,7 @@
-from django.urls import path
+from django.urls import path, re_path
 
-from .views import (GetFacultiesView, GetFieldsOfStudy,
-                    RecruitmentResultListView,
+from .views import (FieldOfStudyContestLaureatesCountView, GetFacultiesView,
+                    GetFieldsOfStudy, RecruitmentResultListView,
                     RecruitmentResultOverviewListView, UploadView)
 
 app_name = 'backend'
@@ -17,4 +17,10 @@ urlpatterns = [
     path('fields_of_studies/',
          GetFieldsOfStudy.as_view(),
          name='fields_of_studies'),
+    path('contest-laureates/',
+         FieldOfStudyContestLaureatesCountView.as_view(),
+         name='contest_laureates'),
+    re_path(r'^contest-laureates/(?P<string>.+)/$',
+            FieldOfStudyContestLaureatesCountView.as_view(),
+            name='get_contest_laureates_count')
 ]

--- a/backend/views.py
+++ b/backend/views.py
@@ -2,7 +2,6 @@ from typing import Any, Dict, List
 
 from django.core.handlers.wsgi import WSGIRequest
 from django.db.models import Avg, Manager, Max, Min
-from django.db.models import Manager
 from django.db.models.aggregates import Count
 from django.http import JsonResponse
 from rest_framework import generics, status
@@ -14,14 +13,11 @@ from rest_framework.response import Response
 from rest_framework.views import APIView
 
 from backend.filters import RecruitmentResultListFilters
-from backend.models import (Faculty, FieldOfStudy, Recruitment,
+from backend.models import (Candidate, Faculty, FieldOfStudy, Recruitment,
                             RecruitmentResult)
 from backend.serializers import (RecruitmentResultFacultiesSerializer,
                                  RecruitmentResultFieldsOfStudySerializer,
                                  RecruitmentResultOverviewSerializer,
-from backend.models import (Candidate, Faculty, FieldOfStudy, Recruitment,
-                            RecruitmentResult)
-from backend.serializers import (RecruitmentResultOverviewSerializer,
                                  RecruitmentResultSerializer)
 
 from .serializers import UploadSerializer

--- a/backend/views.py
+++ b/backend/views.py
@@ -62,17 +62,16 @@ class FieldOfStudyContestLaureatesCountView(APIView):
                 .exclude(contest__isnull=True)\
                 .exclude(contest__exact='')
             print(candidates)
-            recruitment_results = RecruitmentResult.objects.filter(
-                recruitment__in=recruitment, student__in=candidates)
+            recruitment_results = RecruitmentResult.objects\
+                .order_by('-recruitment__year')\
+                .filter(recruitment__in=recruitment, student__in=candidates)
             if recruitment_results:
-                result = list(recruitment_results.values(
-                    'recruitment__year')
+                result = list(recruitment_results.values('recruitment__year')
                               .annotate(contest_laureates=Count('student')))
 
             return Response(result)
-        except Exception as e:
-            print(e)
-            return Response(status=status.HTTP_503_SERVICE_UNAVAILABLE)
+        except Exception:
+            return Response(status=status.HTTP_400_BAD_REQUEST)
 
 
 class UploadView(CreateAPIView):


### PR DESCRIPTION
Stworzyłem endpoint zwracający dla danego kierunku listę z liczbą kandydatów będących laureatami olimpiady na przestrzeni lat.

Metoda HTTP: **GET**
Ścieżka: **/api/backend/contest-laureates/_wydział_+_kierunek_**

Zwracana jest lista obiektów jak na screenie:

![image](https://user-images.githubusercontent.com/58403334/116014217-76687700-a634-11eb-81f8-8b398315e9de.png)

