### PR TITLE
Feature/cha 56 candidates per place

### DIFF
--- a/backend/serializers.py
+++ b/backend/serializers.py
@@ -158,14 +158,13 @@ class RecruitmentResultFieldsOfStudySerializer(
 class FieldOfStudyCandidatesPerPlaceSerializer(
     RecruitmentResultFieldsOfStudySerializer
 ):
-    places = serializers.SerializerMethodField()
     candidates_per_place = serializers.SerializerMethodField()
     year = serializers.SerializerMethodField()
 
     class Meta:
         model = FieldOfStudy
         fields = ('name', 'faculty', 'degree', 'year',
-                  'candidates_count', 'places', 'candidates_per_place')
+                  'candidates_per_place')
 
     def get_year(self, obj: FieldOfStudy) -> int:
         if 'year' not in self.context['request'].data:

--- a/backend/serializers.py
+++ b/backend/serializers.py
@@ -155,6 +155,40 @@ class RecruitmentResultFieldsOfStudySerializer(
         return recruitments_filters
 
 
+class FieldOfStudyCandidatesPerPlaceSerializer(
+    RecruitmentResultFieldsOfStudySerializer
+):
+    places = serializers.SerializerMethodField()
+    candidates_per_place = serializers.SerializerMethodField()
+    year = serializers.SerializerMethodField()
+
+    class Meta:
+        model = FieldOfStudy
+        fields = ('name', 'faculty', 'degree', 'year',
+                  'candidates_count', 'places', 'candidates_per_place')
+
+    def get_year(self, obj: FieldOfStudy) -> int:
+        if 'year' not in self.context['request'].data:
+            raise serializers.ValidationError("Year missing")
+        else:
+            return int(self.context['request'].data['year'])
+
+    def get_places(self, obj: FieldOfStudy) -> Any:
+        places = FieldOfStudyPlacesLimit.objects.filter(
+            field_of_study=obj,
+            year=self.get_year(obj)
+        )
+        return places[0].places if len(places) > 0 else None
+
+    def get_candidates_per_place(self, obj: FieldOfStudy) -> Any:
+        places = self.get_places(obj)
+        if places is None:
+            return None
+        else:
+            result = self.get_candidates_count(obj) / places
+            return result
+
+
 class RecruitmentResultOverviewSerializer(serializers.ModelSerializer[Any]):
     degree = serializers.SerializerMethodField()
     faculty = serializers. \

--- a/backend/urls.py
+++ b/backend/urls.py
@@ -1,6 +1,7 @@
 from django.urls import path, re_path
 
 from backend.views import (AddFacultyView, AddFieldOfStudy,
+                           FieldOfStudyCandidatesPerPlaceListView,
                            FieldOfStudyContestLaureatesCountView, GetBasicData,
                            GetFacultiesView, GetFieldsOfStudy,
                            GetThresholdOnField,
@@ -24,6 +25,9 @@ urlpatterns = [
     path('recruitment-result-fields-of-study/',
          RecruitmentResultFieldsOfStudyListView.as_view(),
          name='recruitment_result_fields_of_study_list'),
+    path('fields-of-study-candidates-per-place/',
+         FieldOfStudyCandidatesPerPlaceListView.as_view(),
+         name='fields_of_study_candidates_per_place'),
     path('upload/', UploadView.as_view(), name='upload_data'),
     path('upload/fields_of_study/<year>/',
          UploadFieldsOfStudyView.as_view(),

--- a/backend/views.py
+++ b/backend/views.py
@@ -139,9 +139,12 @@ class FieldOfStudyCandidatesPerPlaceListView(generics.ListAPIView):
         if 'field_of_study' in self.request.data:
             filters['name'] = self.request.data['field_of_study']
         if 'faculty' in self.request.data:
-            faculty = Faculty.objects.filter(
-                name=self.request.data['faculty'])[0]
-            filters['faculty'] = faculty
+            try:
+                faculty = Faculty.objects.filter(
+                    name=self.request.data['faculty'])[0]
+                filters['faculty'] = faculty
+            except IndexError:
+                return FieldOfStudy.objects.none()
         queryset = FieldOfStudy.objects.filter(**filters)
         return queryset
 

--- a/backend/views.py
+++ b/backend/views.py
@@ -116,9 +116,7 @@ class RecruitmentResultFacultiesListView(generics.ListAPIView):
         return self.list(request, *args, **kwargs)
 
 
-class RecruitmentResultFieldsOfStudyListView(
-    RecruitmentResultFacultiesListView
-):
+class RecruitmentResultFieldsOfStudyListView(generics.ListAPIView):
     serializer_class = RecruitmentResultFieldsOfStudySerializer
 
     def get_queryset(self) -> Manager[FieldOfStudy]:
@@ -126,6 +124,10 @@ class RecruitmentResultFieldsOfStudyListView(
             filter(degree=self.request.data['degree'])\
             if 'degree' in self.request.data else FieldOfStudy.objects.all()
         return queryset
+
+    def post(self, request: Request,
+             *args: List[Any], **kwargs: Dict[Any, Any]) -> Response:
+        return self.list(request, *args, **kwargs)
 
 
 class FieldOfStudyCandidatesPerPlaceListView(

--- a/backend/views.py
+++ b/backend/views.py
@@ -118,6 +118,7 @@ class RecruitmentResultFacultiesListView(generics.ListAPIView):
 
 class RecruitmentResultFieldsOfStudyListView(generics.ListAPIView):
     serializer_class = RecruitmentResultFieldsOfStudySerializer
+    permission_classes = (IsAuthenticated,)
 
     def get_queryset(self) -> Manager[FieldOfStudy]:
         queryset = FieldOfStudy.objects.\

--- a/backend/views.py
+++ b/backend/views.py
@@ -18,6 +18,7 @@ from backend.filters import RecruitmentResultListFilters
 from backend.models import (Candidate, Faculty, FieldOfStudy, Recruitment,
                             RecruitmentResult)
 from backend.serializers import (FacultySerializer, FakeFieldOfStudySerializer,
+                                 FieldOfStudyCandidatesPerPlaceSerializer,
                                  RecruitmentResultFacultiesSerializer,
                                  RecruitmentResultFieldsOfStudySerializer,
                                  RecruitmentResultOverviewSerializer,
@@ -124,6 +125,25 @@ class RecruitmentResultFieldsOfStudyListView(
         queryset = FieldOfStudy.objects.\
             filter(degree=self.request.data['degree'])\
             if 'degree' in self.request.data else FieldOfStudy.objects.all()
+        return queryset
+
+
+class FieldOfStudyCandidatesPerPlaceListView(
+    RecruitmentResultFieldsOfStudyListView
+):
+    serializer_class = FieldOfStudyCandidatesPerPlaceSerializer
+
+    def get_queryset(self) -> Manager[FieldOfStudy]:
+        filters = {}
+        if 'degree' in self.request.data:
+            filters['degree'] = self.request.data['degree']
+        if 'field_of_study' in self.request.data:
+            filters['name'] = self.request.data['field_of_study']
+        if 'faculty' in self.request.data:
+            faculty = Faculty.objects.filter(
+                name=self.request.data['faculty'])[0]
+            filters['faculty'] = faculty
+        queryset = FieldOfStudy.objects.filter(**filters)
         return queryset
 
 

--- a/backend/views.py
+++ b/backend/views.py
@@ -116,9 +116,10 @@ class RecruitmentResultFacultiesListView(generics.ListAPIView):
         return self.list(request, *args, **kwargs)
 
 
-class RecruitmentResultFieldsOfStudyListView(generics.ListAPIView):
+class RecruitmentResultFieldsOfStudyListView(
+    RecruitmentResultFacultiesListView
+):
     serializer_class = RecruitmentResultFieldsOfStudySerializer
-    permission_classes = (IsAuthenticated,)
 
     def get_queryset(self) -> Manager[FieldOfStudy]:
         queryset = FieldOfStudy.objects.\
@@ -126,15 +127,10 @@ class RecruitmentResultFieldsOfStudyListView(generics.ListAPIView):
             if 'degree' in self.request.data else FieldOfStudy.objects.all()
         return queryset
 
-    def post(self, request: Request,
-             *args: List[Any], **kwargs: Dict[Any, Any]) -> Response:
-        return self.list(request, *args, **kwargs)
 
-
-class FieldOfStudyCandidatesPerPlaceListView(
-    RecruitmentResultFieldsOfStudyListView
-):
+class FieldOfStudyCandidatesPerPlaceListView(generics.ListAPIView):
     serializer_class = FieldOfStudyCandidatesPerPlaceSerializer
+    permission_classes = (IsAuthenticated,)
 
     def get_queryset(self) -> Manager[FieldOfStudy]:
         filters = {}
@@ -148,6 +144,10 @@ class FieldOfStudyCandidatesPerPlaceListView(
             filters['faculty'] = faculty
         queryset = FieldOfStudy.objects.filter(**filters)
         return queryset
+
+    def post(self, request: Request,
+             *args: List[Any], **kwargs: Dict[Any, Any]) -> Response:
+        return self.list(request, *args, **kwargs)
 
 
 class FieldOfStudyContestLaureatesCountView(APIView):


### PR DESCRIPTION
Endpoint zwracający liczbę kandydatów na miejsce dla danego kierunku w danym roku na danym stopniu

Ścieżka: **/api/backend/fields-of-study-candidates-per-place/**
Metoda HTTP: **POST**

Body requestu stanowią filtry. Poza _year_ wszystkie filtry są opcjonalne

```json
{
    "year":2019,
    "degree":7,
    "faculty":"WIET",
    "field_of_study":"Informatyka"
}
```

Zwracana jest tablica pasujących obiektów:

```json
{
        "name": "Informatyka",
        "faculty": "WIET",
        "degree": "7",
        "year": 2019,
        "candidates_per_place": 0.005
    }
```