### PR TITLE
CHA-{65,67,68} front - kandydaci, średnia i mediany, status studenta na SCOPE WYDZIAŁU

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1818,6 +1818,18 @@
         "@babel/runtime": "^7.4.4"
       }
     },
+    "@material-ui/lab": {
+      "version": "4.0.0-alpha.58",
+      "resolved": "https://registry.npmjs.org/@material-ui/lab/-/lab-4.0.0-alpha.58.tgz",
+      "integrity": "sha512-GKHlJqLxUeHH3L3dGQ48ZavYrqGOTXkFkiEiuYMAnAvXAZP4rhMIqeHOPXSUQan4Bd8QnafDcpovOSLnadDmKw==",
+      "requires": {
+        "@babel/runtime": "^7.4.4",
+        "@material-ui/utils": "^4.11.2",
+        "clsx": "^1.0.4",
+        "prop-types": "^15.7.2",
+        "react-is": "^16.8.0 || ^17.0.0"
+      }
+    },
     "@material-ui/pickers": {
       "version": "3.3.10",
       "resolved": "https://registry.npmjs.org/@material-ui/pickers/-/pickers-3.3.10.tgz",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,6 +8,7 @@
     "@date-io/moment": "^1.3.13",
     "@material-ui/core": "^4.11.3",
     "@material-ui/icons": "^4.11.2",
+    "@material-ui/lab": "^4.0.0-alpha.58",
     "@material-ui/pickers": "^3.3.10",
     "@material-ui/styles": "^4.11.3",
     "@testing-library/jest-dom": "^5.11.9",

--- a/frontend/src/components/SelectFields/SelectFieldsComponent.js
+++ b/frontend/src/components/SelectFields/SelectFieldsComponent.js
@@ -1,0 +1,32 @@
+import React from 'react';
+import {ToggleButtonGroup, ToggleButton } from '@material-ui/lab'
+import useStyles from "./styles";
+
+const SelectFieldsComponent = ({fields, setFields}) => {
+    const classes = useStyles();
+
+    const [chosenFields, setChosenFields] = React.useState(() => fields);
+
+    const handleFieldsChange = (event, newChosenFields) => {
+        setChosenFields(newChosenFields);
+        setFields(newChosenFields);
+    };
+
+    return(
+        <>
+            <ToggleButtonGroup orientation="horizontal" value={chosenFields} onChange={handleFieldsChange}>
+                {fields.map((name) => (
+                    <ToggleButton 
+                        value={name} aria-label={name}
+                        classes={{root: classes.toggleFields, selected: classes.selectedToggleFields}}
+                    >
+                        <p>{name}</p>
+                    </ToggleButton>
+                    ))}
+            </ToggleButtonGroup>
+        
+        </>
+    );
+}
+
+export default SelectFieldsComponent;

--- a/frontend/src/components/SelectFields/SelectFieldsComponent.js
+++ b/frontend/src/components/SelectFields/SelectFieldsComponent.js
@@ -1,20 +1,40 @@
 import React from 'react';
-import {ToggleButtonGroup, ToggleButton } from '@material-ui/lab'
 import useStyles from "./styles";
+import FormLabel from '@material-ui/core/FormLabel';
+import FormControl from '@material-ui/core/FormControl';
+import FormGroup from '@material-ui/core/FormGroup';
+import FormControlLabel from '@material-ui/core/FormControlLabel';
+import Checkbox from '@material-ui/core/Checkbox';
+
+import {ToggleButtonGroup, ToggleButton } from '@material-ui/lab'
+import FormHelperText from '@material-ui/core/FormHelperText';
 
 const SelectFieldsComponent = ({fields, setFields}) => {
     const classes = useStyles();
 
     const [chosenFields, setChosenFields] = React.useState(() => fields);
 
-    const handleFieldsChange = (event, newChosenFields) => {
-        setChosenFields(newChosenFields);
-        setFields(newChosenFields);
+    const handleFieldsChange = (event) => {
+        let arr;
+        if(event.target.checked) {
+            arr = [
+                ...chosenFields,
+                event.target.name
+            ]
+        } else {
+            arr = chosenFields.filter(name => name !== event.target.name)
+        }
+        setChosenFields(arr);
+        setFields(arr);
+        
+    // const handleFieldsChange = (event, newChosenFields) => {
+        // setChosenFields(newChosenFields);
+        // setFields(newChosenFields);
     };
 
     return(
         <>
-            <ToggleButtonGroup orientation="horizontal" value={chosenFields} onChange={handleFieldsChange}>
+            {/* <ToggleButtonGroup orientation="horizontal" value={chosenFields} onChange={handleFieldsChange}>
                 {fields.map((name) => (
                     <ToggleButton 
                         value={name} aria-label={name}
@@ -23,7 +43,20 @@ const SelectFieldsComponent = ({fields, setFields}) => {
                         <p>{name}</p>
                     </ToggleButton>
                     ))}
-            </ToggleButtonGroup>
+            </ToggleButtonGroup> */}
+
+            <FormControl component="fieldset">
+                <FormLabel component="legend">Kierunki</FormLabel>
+                <FormGroup>
+                    {fields.map((name) => (
+                        <FormControlLabel
+                            control={<Checkbox checked={chosenFields.includes(name)} onChange={handleFieldsChange} name={name} color="primary"/>}
+                            label={name}
+                        />
+                    ))}
+                    
+                </FormGroup>
+            </FormControl>
         
         </>
     );

--- a/frontend/src/components/SelectFields/SelectFieldsComponent.js
+++ b/frontend/src/components/SelectFields/SelectFieldsComponent.js
@@ -1,36 +1,40 @@
 import React from 'react';
-import useStyles from "./styles";
+// import useStyles from "./styles";
 import FormLabel from '@material-ui/core/FormLabel';
 import FormControl from '@material-ui/core/FormControl';
 import FormGroup from '@material-ui/core/FormGroup';
 import FormControlLabel from '@material-ui/core/FormControlLabel';
 import Checkbox from '@material-ui/core/Checkbox';
 
-import {ToggleButtonGroup, ToggleButton } from '@material-ui/lab'
-import FormHelperText from '@material-ui/core/FormHelperText';
+// import {ToggleButtonGroup, ToggleButton } from '@material-ui/lab'
+// import FormHelperText from '@material-ui/core/FormHelperText';
 
-const SelectFieldsComponent = ({fields, setFields}) => {
-    const classes = useStyles();
+function SelectFieldsComponent({fields, setFields}) {
+    // const classes = useStyles();
 
-    const [chosenFields, setChosenFields] = React.useState(() => fields);
+    const [chosenFields, setChosenFields] = React.useState([fields]);
+
+    React.useEffect(() => { 
+        if (!fields.includes(chosenFields[0]) && chosenFields.length !== 0) {
+            setChosenFields(fields)
+            setFields(fields)
+        }
+    });
 
     const handleFieldsChange = (event) => {
-        let arr;
-        if(event.target.checked) {
-            arr = [
-                ...chosenFields,
-                event.target.name
-            ]
-        } else {
-            arr = chosenFields.filter(name => name !== event.target.name)
-        }
+        let arr = (event.target.checked ?
+                [...chosenFields, event.target.name] :
+                chosenFields.filter(name => name !== event.target.name)
+            ).filter(name => fields.includes(name));
+
         setChosenFields(arr);
         setFields(arr);
+    };
         
     // const handleFieldsChange = (event, newChosenFields) => {
         // setChosenFields(newChosenFields);
         // setFields(newChosenFields);
-    };
+    // };
 
     return(
         <>

--- a/frontend/src/components/SelectFields/styles.js
+++ b/frontend/src/components/SelectFields/styles.js
@@ -2,13 +2,13 @@ import { makeStyles } from '@material-ui/styles';
 
 export default makeStyles(theme => ({
 
-    toggleFields: {
-        color: "black",
-        "&$selectedToggleFields": {
-            color: "blue"
-        }
-    },
-    selectedToggleFields: {
-        color: "blue"
-    },
+    // toggleFields: {
+    //     color: "black",
+    //     "&$selectedToggleFields": {
+    //         color: "blue"
+    //     }
+    // },
+    // selectedToggleFields: {
+    //     color: "blue"
+    // },
 }));

--- a/frontend/src/components/SelectFields/styles.js
+++ b/frontend/src/components/SelectFields/styles.js
@@ -1,0 +1,14 @@
+import { makeStyles } from '@material-ui/styles';
+
+export default makeStyles(theme => ({
+
+    toggleFields: {
+        color: "black",
+        "&$selectedToggleFields": {
+            color: "blue"
+        }
+    },
+    selectedToggleFields: {
+        color: "blue"
+    },
+}));

--- a/frontend/src/hooks/useFetchPost.js
+++ b/frontend/src/hooks/useFetchPost.js
@@ -1,0 +1,53 @@
+import { useState } from 'react'
+import { useEffect } from 'react'
+
+import { useAuthState } from '../context/AuthContext'
+
+/*
+Adapted from useFetch.js
+
+Hook for fetching data with POST method. It indicated if request has finished and if there were some errors
+
+@param url - url of resource to fetch
+@param payload - body of post method
+@param initialState - {} for objects or [] for arrays
+@param transformFun - function that can be applied to fetched data before setting them to state
+
+@returns array with fetch data, loading indicator, error indicator
+*/
+
+const useFetchPost = (url, payload, initialState, transformFun = (arg) => arg) => {
+    const [data, setData] = useState(initialState)
+    const [isLoading, setIsLoading] = useState(true)
+    const [hasError, setHasError] = useState(false)
+
+    const authState = useAuthState()
+
+    useEffect(() => {
+        fetch(url, {
+            method: "POST",
+            headers: {
+                'Content-Type': 'application/json',
+                'Authorization': `Bearer ${authState.access}`,
+            },
+            body: JSON.stringify(payload)
+        }).then(response => {
+            if (response.ok) return response.json()
+            else {
+                setIsLoading(false)
+                setHasError(true)
+                throw new Error(`Response code is ${response.status}`)
+            }
+        }).then(json => {
+            setData(transformFun(json))
+            setIsLoading(false)
+        })
+        .catch(e => console.log(e))
+
+    }, [url])
+
+
+    return [data, isLoading, hasError]
+}
+
+export default useFetchPost

--- a/frontend/src/pages/ChangePassword/ChangePasswordPanel.js
+++ b/frontend/src/pages/ChangePassword/ChangePasswordPanel.js
@@ -29,7 +29,7 @@ function ChangePasswordPanel(props) {
             })
             setStatus(await response.status);
             setOld("");
-            if(await response.status=="200") setOldCheck(false);
+            if(await response.status==="200") setOldCheck(false);
         }
         catch (error) {
             console.log(error)
@@ -63,16 +63,16 @@ function ChangePasswordPanel(props) {
                             <Grid container>
                                 <Grid item xs={12} className={(classes.margin, classes.center)}>
                                     {
-                                        (status=="400" || status=="500") ?
+                                        (status==="400" || status==="500") ?
                                         <Typography
                                             variant='body1'
                                             color='error'
                                             align="center"
                                         >
-                                            {(status=="400") ? "Nie zmieniono hasła. Poprawnie wpisałeś stare hasło?" :
+                                            {(status==="400") ? "Nie zmieniono hasła. Poprawnie wpisałeś stare hasło?" :
                                             "Brak połączenia z serwerem"}
                                         </Typography> :
-                                        (status=="200" ?
+                                        (status==="200" ?
                                         <Typography
                                             variant='body1'
                                             color='primary'

--- a/frontend/src/pages/FacultyAnalysis/Charts/AveragesMediandsChart.js
+++ b/frontend/src/pages/FacultyAnalysis/Charts/AveragesMediandsChart.js
@@ -12,9 +12,13 @@ const options = {
 };
 
 
-export default function AveragesMediansChart({ faculty , cycle, allowedFields}) {
+export default function AveragesMediansChart({ faculty , cycle, year, allowedFields}) {
 
     const convertResult = (json) => {
+        if(Object.keys(json).includes(`${faculty} ${year}`)) {
+            json = GetReducedFields(json[`${faculty} ${year}`], allowedFields)
+        }
+
         const result = { 
             labels: Object.keys(json),
             datasets: [{
@@ -40,8 +44,7 @@ export default function AveragesMediansChart({ faculty , cycle, allowedFields}) 
         return result
     }
 
-    //TODO zmienic jak będzie endpoint
-    //const [fetchedData, loading, error ] = useFetch(`/api/backend/aam/${faculty}+2020/`, {}, convertResult)
+    //const [fetchedData, loading, error ] = useFetch(`/api/backend/aam/${faculty}+${year}/`, {}, convertResult)
     const fetchedData = {
         "WIET 2020": {
             "Informatyka": {
@@ -54,7 +57,6 @@ export default function AveragesMediansChart({ faculty , cycle, allowedFields}) 
             },
         },
     }
-    const fieldsOfStudyData = fetchedData["WIET 2020"];
     
     return (
         <Card  >
@@ -64,7 +66,7 @@ export default function AveragesMediansChart({ faculty , cycle, allowedFields}) 
             />
             <CardContent>
                 <div >
-                    <Bar data={convertResult(GetReducedFields(fieldsOfStudyData, allowedFields))} options={options}/>
+                    <Bar data={convertResult(fetchedData)} options={options}/>
                 </div>
             </CardContent>
         </Card>

--- a/frontend/src/pages/FacultyAnalysis/Charts/AveragesMediandsChart.js
+++ b/frontend/src/pages/FacultyAnalysis/Charts/AveragesMediandsChart.js
@@ -12,7 +12,7 @@ const options = {
 };
 
 
-export default function AveragesMediansChart({ faculty , allowedFields}) {
+export default function AveragesMediansChart({ faculty , cycle, allowedFields}) {
 
     const convertResult = (json) => {
         const result = { 
@@ -79,7 +79,7 @@ export default function AveragesMediansChart({ faculty , allowedFields}) {
         <Card  >
             <CardHeader
                 style={{ textAlign: 'center' }}
-                title={<Typography variant='h5'>Liczba kandydatów na jedno miejsce</Typography>}
+                title={<Typography variant='h5'>Średnia i mediana kandydatów na kierunki</Typography>}
             />
             <CardContent>
                 <div >

--- a/frontend/src/pages/FacultyAnalysis/Charts/AveragesMediandsChart.js
+++ b/frontend/src/pages/FacultyAnalysis/Charts/AveragesMediandsChart.js
@@ -30,8 +30,11 @@ export default function AveragesMediansChart({ faculty , cycle, allowedFields}) 
         ]}
 
         Object.keys(json).forEach(k => {
-            result.datasets[0].data.push(json[k]["AVG"]);
-            result.datasets[1].data.push(json[k]["MED"]);
+            Object.keys(json[k]).forEach(type => {
+                result.datasets[
+                    Object.keys(json[k]).indexOf(type)
+                ].data.push(json[k][type]);
+            })
         })
 
         return result

--- a/frontend/src/pages/FacultyAnalysis/Charts/AveragesMediandsChart.js
+++ b/frontend/src/pages/FacultyAnalysis/Charts/AveragesMediandsChart.js
@@ -1,0 +1,59 @@
+import React from 'react'
+import { Bar } from 'react-chartjs-2';
+import { Card, CardHeader, CardContent, Typography } from '@material-ui/core'
+import useFetch from '../../../hooks/useFetch';
+import { colors, commonOptions } from './settings'
+import { GetReducedFields } from '../FacultyAnalysis';
+
+
+const options = {
+    ...commonOptions,
+    aspectRatio: 3,
+};
+
+
+export default function AveragesMediansChart({ faculty , cycle, allowedFields}) {
+
+    const convertResult = (json) => {
+        const result = { 
+            labels: Object.keys(json),
+            datasets: [{
+                label: "Liczba kandydatów na jedno miejsce",
+                data: Object.values(json),
+                backgroundColor: colors,
+            }],
+        }
+
+        return result
+    }
+
+
+    //TODO odkomentować jak będzie endpoint
+    //const [fieldsOfStudyData, loading, error ] = useFetch(`/api/backend/candidates_number_per_place?faculty=${faculty}`, {}, convertResult)
+
+
+    //TODO usnąć jak będą pobierane dane
+    const fieldsOfStudyData = {
+        informatyka: 10,
+        elektrotechnika: 1,
+        telekomunikacja: 2,
+        cyberbezpieczeństwo: 2,
+        random: 5,
+        org: 1,
+        kolejnykierunek: 6,
+    }
+            
+    return (
+        <Card  >
+            <CardHeader
+                style={{ textAlign: 'center' }}
+                title={<Typography variant='h5'>Liczba kandydatów na jedno miejsce</Typography>}
+            />
+            <CardContent>
+                <div >
+                    <Bar data={convertResult(GetReducedFields(fieldsOfStudyData, allowedFields))} options={options}/>
+                </div>
+            </CardContent>
+        </Card>
+    )
+}

--- a/frontend/src/pages/FacultyAnalysis/Charts/AveragesMediandsChart.js
+++ b/frontend/src/pages/FacultyAnalysis/Charts/AveragesMediandsChart.js
@@ -30,56 +30,34 @@ export default function AveragesMediansChart({ faculty , cycle, allowedFields}) 
         ]}
 
         Object.keys(json).forEach(k => {
-            result.datasets[0].data.push(json[k]["average"]);
-            result.datasets[1].data.push(json[k]["median"]);
+            result.datasets[0].data.push(json[k]["AVG"]);
+            result.datasets[1].data.push(json[k]["MED"]);
         })
 
         return result
     }
 
-
-    //TODO odkomentować jak będzie endpoint
-    //const [fieldsOfStudyData, loading, error ] = useFetch(`/api/backend/candidates_number_per_place?faculty=${faculty}`, {}, convertResult)
-
-
-    //TODO usnąć jak będą pobierane dane
-    const fieldsOfStudyData = {
-        informatyka: {
-            average: 900,
-            median: 800,
-        },
-        elektrotechnika: {
-            average: 300,
-            median: 100,
-        },
-        telekomunikacja: {
-            average: 900,
-            median: 400,
-        },
-        cyberbezpieczeństwo: {
-            average: 400,
-            median: 800,
-        },
-        random: {
-            average: 550,
-            median: 600,
-        },
-        org: {
-            average:900,
-            median:800,
-        },
-        kolejnykierunek: {
-            average:900,
-            median:800,
+    //TODO zmienic jak będzie endpoint
+    //const [fetchedData, loading, error ] = useFetch(`/api/backend/aam/${faculty}+2020/`, {}, convertResult)
+    const fetchedData = {
+        "WIET 2020": {
+            "Informatyka": {
+                "AVG": 900,
+                "MED": 800,
+            },
+            "Elektornika": {
+                "AVG": 300,
+                "MED": 100,
+            },
         },
     }
-    
+    const fieldsOfStudyData = fetchedData["WIET 2020"];
     
     return (
         <Card  >
             <CardHeader
                 style={{ textAlign: 'center' }}
-                title={<Typography variant='h5'>Średnia i mediana kandydatów na kierunki</Typography>}
+                title={<Typography variant='h5'>Średnia i mediana kandydatów na kierunek</Typography>}
             />
             <CardContent>
                 <div >

--- a/frontend/src/pages/FacultyAnalysis/Charts/AveragesMediandsChart.js
+++ b/frontend/src/pages/FacultyAnalysis/Charts/AveragesMediandsChart.js
@@ -12,17 +12,27 @@ const options = {
 };
 
 
-export default function AveragesMediansChart({ faculty , cycle, allowedFields}) {
+export default function AveragesMediansChart({ faculty , allowedFields}) {
 
     const convertResult = (json) => {
         const result = { 
             labels: Object.keys(json),
             datasets: [{
-                label: "Liczba kandydatów na jedno miejsce",
-                data: Object.values(json),
-                backgroundColor: colors,
-            }],
-        }
+                label: "Średnia",
+                data: [],
+                backgroundColor: colors[0],
+            },
+            {
+                label: "Mediana",
+                data: [],
+                backgroundColor: colors[1],
+            }
+        ]}
+
+        Object.keys(json).forEach(k => {
+            result.datasets[0].data.push(json[k]["average"]);
+            result.datasets[1].data.push(json[k]["median"]);
+        })
 
         return result
     }
@@ -34,15 +44,37 @@ export default function AveragesMediansChart({ faculty , cycle, allowedFields}) 
 
     //TODO usnąć jak będą pobierane dane
     const fieldsOfStudyData = {
-        informatyka: 10,
-        elektrotechnika: 1,
-        telekomunikacja: 2,
-        cyberbezpieczeństwo: 2,
-        random: 5,
-        org: 1,
-        kolejnykierunek: 6,
+        informatyka: {
+            average: 900,
+            median: 800,
+        },
+        elektrotechnika: {
+            average: 300,
+            median: 100,
+        },
+        telekomunikacja: {
+            average: 900,
+            median: 400,
+        },
+        cyberbezpieczeństwo: {
+            average: 400,
+            median: 800,
+        },
+        random: {
+            average: 550,
+            median: 600,
+        },
+        org: {
+            average:900,
+            median:800,
+        },
+        kolejnykierunek: {
+            average:900,
+            median:800,
+        },
     }
-            
+    
+    
     return (
         <Card  >
             <CardHeader

--- a/frontend/src/pages/FacultyAnalysis/Charts/CandidatesNumChart.js
+++ b/frontend/src/pages/FacultyAnalysis/Charts/CandidatesNumChart.js
@@ -1,0 +1,58 @@
+import React from 'react'
+import { Bar } from 'react-chartjs-2';
+import { Card, CardHeader, CardContent, Typography } from '@material-ui/core'
+import { colors, commonOptions } from './settings'
+import { GetReducedFields } from '../FacultyAnalysis';
+
+
+const options = {
+    ...commonOptions,
+    aspectRatio: 3,
+};
+
+
+export default function CandidatesNumChart({ faculty , cycle, allowedFields}) {
+
+    const convertResult = (json) => {
+        const result = { 
+            labels: Object.keys(json),
+            datasets: [{
+                label: "Liczba kandydatów na jedno miejsce",
+                data: Object.values(json),
+                backgroundColor: colors,
+            }],
+        }
+
+        return result
+    }
+
+
+    //TODO odkomentować jak będzie endpoint
+    //const [fieldsOfStudyData, loading, error ] = useFetch(`/api/backend/candidates_number_per_place?faculty=${faculty}`, {}, convertResult)
+
+
+    //TODO usnąć jak będą pobierane dane
+    const fieldsOfStudyData = {
+        informatyka: 10,
+        elektrotechnika: 1,
+        telekomunikacja: 2,
+        cyberbezpieczeństwo: 2,
+        random: 5,
+        org: 1,
+        kolejnykierunek: 6,
+    }
+            
+    return (
+        <Card  >
+            <CardHeader
+                style={{ textAlign: 'center' }}
+                title={<Typography variant='h5'>Liczba kandydatów na jedno miejsce</Typography>}
+            />
+            <CardContent>
+                <div >
+                    <Bar data={convertResult(GetReducedFields(fieldsOfStudyData, allowedFields))} options={options}/>
+                </div>
+            </CardContent>
+        </Card>
+    )
+}

--- a/frontend/src/pages/FacultyAnalysis/Charts/CandidatesNumChart.js
+++ b/frontend/src/pages/FacultyAnalysis/Charts/CandidatesNumChart.js
@@ -51,6 +51,13 @@ export default function CandidatesNumChart({ faculty, cycle, allowedFields}) {
             "degree": "7",
             "year": 2020,
             "candidates_per_place": 0.015
+        },
+        {
+            "name":"Odlewnictwo",
+            "faculty": "WO",
+            "degree": "7",
+            "year": 2020,
+            "candidates_per_place": 15
         }
     ]
             

--- a/frontend/src/pages/FacultyAnalysis/Charts/CandidatesNumChart.js
+++ b/frontend/src/pages/FacultyAnalysis/Charts/CandidatesNumChart.js
@@ -10,9 +10,10 @@ const options = {
 };
 
 
-export default function CandidatesNumChart({ faculty, cycle, allowedFields}) {
+export default function CandidatesNumChart({ faculty, cycle, year, allowedFields}) {
 
     const convertResult = (json) => {
+        json = GetReducedArray(json, allowedFields)
         const result = { 
             labels: [],
             datasets: [{
@@ -31,12 +32,11 @@ export default function CandidatesNumChart({ faculty, cycle, allowedFields}) {
     }
 
     // const payload = {
-    //     "year":2020, //TODO think about it, maybe add everywhere year?
+    //     "year":year,
     //     "degree":cycle,
     //     "faculty":faculty
     // }
     // const [fieldsOfStudyData, loading, error] = useFetchPost('/api/backend/fields-of-study-candidates-per-place/', payload, [], convertResult);
-    //TODO usnąć jak będą pobierane dane
     const fieldsOfStudyData = [
         {
             "name":"Informatyka",
@@ -69,7 +69,7 @@ export default function CandidatesNumChart({ faculty, cycle, allowedFields}) {
             />
             <CardContent>
                 <div >
-                    <Bar data={convertResult(GetReducedArray(fieldsOfStudyData, allowedFields))} options={options}/>
+                    <Bar data={convertResult(fieldsOfStudyData)} options={options}/>
                 </div>
             </CardContent>
         </Card>

--- a/frontend/src/pages/FacultyAnalysis/Charts/CandidatesNumChart.js
+++ b/frontend/src/pages/FacultyAnalysis/Charts/CandidatesNumChart.js
@@ -11,7 +11,7 @@ const options = {
 };
 
 
-export default function CandidatesNumChart({ faculty, allowedFields}) {
+export default function CandidatesNumChart({ faculty, cycle, allowedFields}) {
 
     const convertResult = (json) => {
         const result = { 

--- a/frontend/src/pages/FacultyAnalysis/Charts/CandidatesNumChart.js
+++ b/frontend/src/pages/FacultyAnalysis/Charts/CandidatesNumChart.js
@@ -2,8 +2,7 @@ import React from 'react'
 import { Bar } from 'react-chartjs-2';
 import { Card, CardHeader, CardContent, Typography } from '@material-ui/core'
 import { colors, commonOptions } from './settings'
-import { GetReducedFields } from '../FacultyAnalysis';
-
+import { GetReducedArray } from '../FacultyAnalysis';
 
 const options = {
     ...commonOptions,
@@ -15,32 +14,45 @@ export default function CandidatesNumChart({ faculty, cycle, allowedFields}) {
 
     const convertResult = (json) => {
         const result = { 
-            labels: Object.keys(json),
+            labels: [],
             datasets: [{
                 label: "Liczba kandydatów na jedno miejsce",
-                data: Object.values(json),
+                data: [],
                 backgroundColor: colors,
             }],
         }
 
+        json.forEach( lit => {
+            result.labels.push(lit["name"]);
+            result.datasets[0].data.push(lit["candidates_per_place"]);
+        })
+
         return result
     }
 
-
-    //TODO odkomentować jak będzie endpoint
-    //const [fieldsOfStudyData, loading, error ] = useFetch(`/api/backend/candidates_number_per_place?faculty=${faculty}`, {}, convertResult)
-
-
+    // const payload = {
+    //     "year":2020, //TODO think about it, maybe add everywhere year?
+    //     "degree":cycle,
+    //     "faculty":faculty
+    // }
+    // const [fieldsOfStudyData, loading, error] = useFetchPost('/api/backend/fields-of-study-candidates-per-place/', payload, [], convertResult);
     //TODO usnąć jak będą pobierane dane
-    const fieldsOfStudyData = {
-        informatyka: 10,
-        elektrotechnika: 1,
-        telekomunikacja: 2,
-        cyberbezpieczeństwo: 2,
-        random: 5,
-        org: 1,
-        kolejnykierunek: 6,
-    }
+    const fieldsOfStudyData = [
+        {
+            "name":"Informatyka",
+            "faculty": "WIET",
+            "degree": "7",
+            "year": 2020,
+            "candidates_per_place": 0.005
+        },
+        {
+            "name":"Elektornika",
+            "faculty": "WIET",
+            "degree": "7",
+            "year": 2020,
+            "candidates_per_place": 0.015
+        }
+    ]
             
     return (
         <Card  >
@@ -50,7 +62,7 @@ export default function CandidatesNumChart({ faculty, cycle, allowedFields}) {
             />
             <CardContent>
                 <div >
-                    <Bar data={convertResult(GetReducedFields(fieldsOfStudyData, allowedFields))} options={options}/>
+                    <Bar data={convertResult(GetReducedArray(fieldsOfStudyData, allowedFields))} options={options}/>
                 </div>
             </CardContent>
         </Card>

--- a/frontend/src/pages/FacultyAnalysis/Charts/CandidatesNumChart.js
+++ b/frontend/src/pages/FacultyAnalysis/Charts/CandidatesNumChart.js
@@ -11,7 +11,7 @@ const options = {
 };
 
 
-export default function CandidatesNumChart({ faculty , cycle, allowedFields}) {
+export default function CandidatesNumChart({ faculty, allowedFields}) {
 
     const convertResult = (json) => {
         const result = { 

--- a/frontend/src/pages/FacultyAnalysis/Charts/Cycle2ndChart.js
+++ b/frontend/src/pages/FacultyAnalysis/Charts/Cycle2ndChart.js
@@ -17,7 +17,7 @@ export default function Cycle2ndChart({ faculty, allowedFields}) {
         const result = { 
             labels: Object.keys(json),
             datasets: [{
-                label: "Liczba laureatów kandydujących na kierunek",
+                label: "CHA 66 TODOO",
                 data: Object.values(json),
                 backgroundColor: colors,
             }]
@@ -45,7 +45,7 @@ export default function Cycle2ndChart({ faculty, allowedFields}) {
         <Card  >
             <CardHeader
                 style={{ textAlign: 'center' }}
-                title={<Typography variant='h5'>STUDENCIAKI TODO</Typography>}
+                title={<Typography variant='h5'>CHA-66 TODO</Typography>}
             />
             <CardContent>
                 <div >

--- a/frontend/src/pages/FacultyAnalysis/Charts/Cycle2ndChart.js
+++ b/frontend/src/pages/FacultyAnalysis/Charts/Cycle2ndChart.js
@@ -1,0 +1,58 @@
+import React from 'react'
+import { Bar } from 'react-chartjs-2';
+import { Card, CardHeader, CardContent, Typography } from '@material-ui/core'
+import useFetch from '../../../hooks/useFetch';
+import { colors, commonOptions } from './settings'
+import { GetReducedFields } from '../FacultyAnalysis';
+
+const options = {
+    ...commonOptions,
+    aspectRatio: 3,
+};
+
+
+export default function Cycle2ndChart({ faculty, allowedFields}) {
+
+    const convertResult = (json) => {
+        const result = { 
+            labels: Object.keys(json),
+            datasets: [{
+                label: "Liczba laureatów kandydujących na kierunek",
+                data: Object.values(json),
+                backgroundColor: colors,
+            }]
+        }
+
+        return result
+    }
+
+    //TODO odkomentować jak będzie endpoint
+    //const [fieldsOfStudyData, loading, error ] = useFetch(`/api/backend/actual_recruitment_faculty_laureate?faculty=${faculty}`, {}, convertResult)
+
+
+    //TODO usnąć jak będą pobierane dane
+    const fakeData = {
+        informatyka: 100,
+        elektrotechnika: 30,
+        telekomunikacja: 47,
+        cyberbezpieczeństwo: 90,
+        random: 5,
+        org: 13,
+        kolejnykierunek: 17,
+    }
+
+    return (
+        <Card  >
+            <CardHeader
+                style={{ textAlign: 'center' }}
+                title={<Typography variant='h5'>STUDENCIAKI TODO</Typography>}
+            />
+            <CardContent>
+                <div >
+                    {/* TODO change data to real data */}
+                    <Bar data={convertResult(GetReducedFields(fakeData, allowedFields))} options={options} />
+                </div>
+            </CardContent>
+        </Card>
+    )
+}

--- a/frontend/src/pages/FacultyAnalysis/Charts/LaureateChart.js
+++ b/frontend/src/pages/FacultyAnalysis/Charts/LaureateChart.js
@@ -3,7 +3,7 @@ import { Bar } from 'react-chartjs-2';
 import { Card, CardHeader, CardContent, Typography } from '@material-ui/core'
 import useFetch from '../../../hooks/useFetch';
 import { colors, commonOptions } from './settings'
-
+import { GetReducedFields } from '../FacultyAnalysis';
 
 const options = {
     ...commonOptions,
@@ -11,7 +11,7 @@ const options = {
 };
 
 
-export default function LaureateChart({ faculty }) {
+export default function LaureateChart({ faculty, allowedFields}) {
 
     const convertResult = (json) => {
         const result = { 
@@ -50,7 +50,7 @@ export default function LaureateChart({ faculty }) {
             <CardContent>
                 <div >
                     {/* TODO change data to real data */}
-                    <Bar data={convertResult(fakeData)} options={options} />
+                    <Bar data={convertResult(GetReducedFields(fakeData, allowedFields))} options={options} />
                 </div>
             </CardContent>
         </Card>

--- a/frontend/src/pages/FacultyAnalysis/Charts/LaureateChart.js
+++ b/frontend/src/pages/FacultyAnalysis/Charts/LaureateChart.js
@@ -14,6 +14,7 @@ const options = {
 export default function LaureateChart({ faculty, allowedFields}) {
 
     const convertResult = (json) => {
+        json = GetReducedFields(json, allowedFields)
         const result = { 
             labels: Object.keys(json),
             datasets: [{
@@ -50,7 +51,7 @@ export default function LaureateChart({ faculty, allowedFields}) {
             <CardContent>
                 <div >
                     {/* TODO change data to real data */}
-                    <Bar data={convertResult(GetReducedFields(fakeData, allowedFields))} options={options} />
+                    <Bar data={convertResult(fakeData)} options={options} />
                 </div>
             </CardContent>
         </Card>

--- a/frontend/src/pages/FacultyAnalysis/Charts/LaureateChart.js
+++ b/frontend/src/pages/FacultyAnalysis/Charts/LaureateChart.js
@@ -32,8 +32,8 @@ export default function LaureateChart({ faculty, allowedFields}) {
 
     //TODO usnąć jak będą pobierane dane
     const fakeData = {
-        informatyka: 100,
-        elektrotechnika: 30,
+        Informatyka: 100,
+        Elektornika: 30,
         telekomunikacja: 47,
         cyberbezpieczeństwo: 90,
         random: 5,

--- a/frontend/src/pages/FacultyAnalysis/Charts/StudentsStatusChart.js
+++ b/frontend/src/pages/FacultyAnalysis/Charts/StudentsStatusChart.js
@@ -1,70 +1,136 @@
 import React from 'react'
 import { Bar } from 'react-chartjs-2';
-import { Card, CardHeader, CardContent, Typography } from '@material-ui/core'
+import { Card, CardHeader, CardContent, Typography, Grid } from '@material-ui/core'
 import useFetch from '../../../hooks/useFetch';
 import { colors, commonOptions } from './settings'
 import { GetReducedFields } from '../FacultyAnalysis';
 
 const options = {
     ...commonOptions,
-    aspectRatio: 5,
+    aspectRatio: 4,
 };
 
-
-
-export default function StudentsStatusChart({ faculty, cycle, allowedFields }) {
+export default function StudentsStatusChart({ faculty, cycle, year, allowedFields }) {
 
     //converts the result of fetched json to format accepted by chart component
     const convertResult = (json) => {
-        const result = { labels: Object.keys(json), datasets: [] }
-
-        if(typeof json[result.labels[0]] !== "undefined") {
-            for (let index = 1; index <= json[result.labels[0]].length; index++) {
+        const result = { labels: [], datasets: [] }
+        
+        Object.keys(json).filter(key => key !== "all").forEach(key => {
+            result.labels.push('Cykl ' + key)
+        })
+        
+        Object.keys(json[Object.keys(json)[0]]).forEach(key => {
+            if(key !== "all") {
                 result.datasets.push({
-                    label: `Próg w cyklu ${index}`,
+                    label: key,
                     data: [],
-                    backgroundColor: colors[index - 1]
+                    backgroundColor: colors[Object.keys(json[Object.keys(json)[0]]).indexOf(key)],
                 })
             }
-        }
+        })
 
-        Object.keys(json).forEach(key => {
-            json[key].forEach((val, idx) => {
-                result.datasets[idx].data.push(val)
-            })
+        Object.keys(json).forEach( key => {
+            if(key !== "all"){
+                var stats = json[key]
+                Object.keys(stats).forEach (statusKey => {
+                    var points = stats[statusKey];
+                    result.datasets[
+                        Object.keys(stats).indexOf(statusKey)
+                    ].data.push(
+                        points
+                    )
+                })
+            }
         })
 
         return result
     }
 
+
+    //const [fieldsOfStudyData, loading, error ] = useFetch(`/api/backend/status-distribution/${year}/${faculty}/${cycle}/`, {}, e=>e)
     //TODO usnąć po tym jak będzie możliwosć pobierania
-    const fakeData = {
-        informatyka: [960, 960, 960, 960],
-        elektrotechnika: [890, 870, 840, 840],
-        telekomunikacja: [920, 900, 890, 880],
-        cyberbezpieczeństwo: [950, 940, 940, 938],
-        random: [960, 960, 960, 960],
-        org: [890, 870, 840, 840],
-        kolejnykierunek: [920, 900, 890, 880],
+    const fieldsOfStudyData = {
+        "all": {
+            status1: 1000,
+            status2: 2000,
+        },
+        Informatyka: {
+            "all": {
+                status1: 1000,
+                status2: 2100,
+            },
+            "1": {
+                status1: 120,
+                status2: 220,
+            },
+            "2": {
+                status1: 130,
+                status2: 230,
+            },
+            "3": {
+                status1: 140,
+                status2: 240,
+            },
+            "4": {
+                status1: 150,
+                status2: 250,
+            }
+        },
+        Elektornika: {
+            "all": {
+                status1: 1010,
+                status2: 20010,
+            },
+            "1": {
+                status1: 10,
+                status2: 20,
+            },
+            "2": {
+                status1: 130,
+                status2: 20,
+            },
+            "3": {
+                status1: 140,
+                status2: 40,
+            },
+            "4": {
+                status1: 10,
+                status2: 90,
+            }
+        }
     }
 
-    //TODO odkomentować i sprawdzić, gdy już będzie gotowy endpoint
-    //const [fieldsOfStudyData, loading, error ] = useFetch(`/api/backend/actual_recruitment_faculty_threshold?faculty=${faculty}&cycle=${cycle}`, {}, convertResult)
-
-
     return (
-        <Card  >
+        <Card>
             <CardHeader
                 style={{ textAlign: 'center' }}
-                title={<Typography variant='h5'>CHA-60 WIP</Typography>}
+                title={<Typography variant='h5'>Status studentów dla danego kierunku w cyklach</Typography>}
             />
             <CardContent>
-                <div >
-                    {/* TODO change data to real data */}
-                    <Bar data={convertResult(GetReducedFields(fakeData, allowedFields))} options={options} />
-                </div>
-            </CardContent>
+                <Grid container spacing={1}>
 
+            {Object.keys(GetReducedFields(fieldsOfStudyData, allowedFields)).map((name) => {
+                let amount = 1;
+                let keys = Object.keys(GetReducedFields(fieldsOfStudyData, allowedFields))
+                if(keys.indexOf(name) == keys.length - 1 && keys.length % 2 == 1) {
+                        amount = 2;
+                    }
+                return(
+                <Grid item xs={12} md={6*amount}>
+                    <Card variant="outlined">
+                    <CardHeader
+                        style={{ textAlign: 'center', backgroundColor: "#fcfcfc", paddingBottom:0, paddingTop:5}}
+                        title={<Typography variant='subtitle1'>{name}</Typography>}
+                    />
+                    <CardContent style={{backgroundColor: "#fcfcfc",padding:0}}>
+                        <Bar data={convertResult(fieldsOfStudyData[name])} options={options} />
+                    </CardContent>
+                    </Card>
+                </Grid>)
+            })}
+            </Grid>
+            </CardContent>
         </Card>
     )
 }

--- a/frontend/src/pages/FacultyAnalysis/Charts/StudentsStatusChart.js
+++ b/frontend/src/pages/FacultyAnalysis/Charts/StudentsStatusChart.js
@@ -1,0 +1,68 @@
+import React from 'react'
+import { Bar } from 'react-chartjs-2';
+import { Card, CardHeader, CardContent, Typography } from '@material-ui/core'
+import useFetch from '../../../hooks/useFetch';
+import { colors, commonOptions } from './settings'
+import { GetReducedFields } from '../FacultyAnalysis';
+
+const options = {
+    ...commonOptions,
+    aspectRatio: 5,
+};
+
+
+
+export default function StudentsStatusChart({ faculty, cycle, allowedFields }) {
+
+    //converts the result of fetched json to format accepted by chart component
+    const convertResult = (json) => {
+        const result = { labels: Object.keys(json), datasets: [] }
+
+        for (let index = 1; index <= json[result.labels[0]].length; index++) {
+            result.datasets.push({
+                label: `Próg w cyklu ${index}`,
+                data: [],
+                backgroundColor: colors[index - 1]
+            })
+        }
+
+        Object.keys(json).forEach(key => {
+            json[key].forEach((val, idx) => {
+                result.datasets[idx].data.push(val)
+            })
+        })
+
+        return result
+    }
+
+    //TODO usnąć po tym jak będzie możliwosć pobierania
+    const fakeData = {
+        informatyka: [960, 960, 960, 960],
+        elektrotechnika: [890, 870, 840, 840],
+        telekomunikacja: [920, 900, 890, 880],
+        cyberbezpieczeństwo: [950, 940, 940, 938],
+        random: [960, 960, 960, 960],
+        org: [890, 870, 840, 840],
+        kolejnykierunek: [920, 900, 890, 880],
+    }
+
+    //TODO odkomentować i sprawdzić, gdy już będzie gotowy endpoint
+    //const [fieldsOfStudyData, loading, error ] = useFetch(`/api/backend/actual_recruitment_faculty_threshold?faculty=${faculty}&cycle=${cycle}`, {}, convertResult)
+
+
+    return (
+        <Card  >
+            <CardHeader
+                style={{ textAlign: 'center' }}
+                title={<Typography variant='h5'>STATUS ZMIEN MNIE</Typography>}
+            />
+            <CardContent>
+                <div >
+                    {/* TODO change data to real data */}
+                    <Bar data={convertResult(GetReducedFields(fakeData, allowedFields))} options={options} />
+                </div>
+            </CardContent>
+
+        </Card>
+    )
+}

--- a/frontend/src/pages/FacultyAnalysis/Charts/StudentsStatusChart.js
+++ b/frontend/src/pages/FacultyAnalysis/Charts/StudentsStatusChart.js
@@ -14,6 +14,7 @@ export default function StudentsStatusChart({ faculty, cycle, year, allowedField
 
     //converts the result of fetched json to format accepted by chart component
     const convertResult = (json) => {
+        //TODO prawdopodobnie da sie uproscic
         const result = { labels: [], datasets: [] }
         
         Object.keys(json).filter(key => key !== "all").forEach(key => {
@@ -35,11 +36,7 @@ export default function StudentsStatusChart({ faculty, cycle, year, allowedField
                 var stats = json[key]
                 Object.keys(stats).forEach (statusKey => {
                     var points = stats[statusKey];
-                    result.datasets[
-                        Object.keys(stats).indexOf(statusKey)
-                    ].data.push(
-                        points
-                    )
+                    result.datasets[Object.keys(stats).indexOf(statusKey)].data.push(points)
                 })
             }
         })
@@ -49,7 +46,6 @@ export default function StudentsStatusChart({ faculty, cycle, year, allowedField
 
 
     //const [fieldsOfStudyData, loading, error ] = useFetch(`/api/backend/status-distribution/${year}/${faculty}/${cycle}/`, {}, e=>e)
-    //TODO usnąć po tym jak będzie możliwosć pobierania
     const fieldsOfStudyData = {
         "all": {
             status1: 1000,

--- a/frontend/src/pages/FacultyAnalysis/Charts/StudentsStatusChart.js
+++ b/frontend/src/pages/FacultyAnalysis/Charts/StudentsStatusChart.js
@@ -56,7 +56,7 @@ export default function StudentsStatusChart({ faculty, cycle, allowedFields }) {
         <Card  >
             <CardHeader
                 style={{ textAlign: 'center' }}
-                title={<Typography variant='h5'>STATUS ZMIEN MNIE</Typography>}
+                title={<Typography variant='h5'>CHA-60 WIP</Typography>}
             />
             <CardContent>
                 <div >

--- a/frontend/src/pages/FacultyAnalysis/Charts/StudentsStatusChart.js
+++ b/frontend/src/pages/FacultyAnalysis/Charts/StudentsStatusChart.js
@@ -18,12 +18,14 @@ export default function StudentsStatusChart({ faculty, cycle, allowedFields }) {
     const convertResult = (json) => {
         const result = { labels: Object.keys(json), datasets: [] }
 
-        for (let index = 1; index <= json[result.labels[0]].length; index++) {
-            result.datasets.push({
-                label: `Próg w cyklu ${index}`,
-                data: [],
-                backgroundColor: colors[index - 1]
-            })
+        if(typeof json[result.labels[0]] !== "undefined") {
+            for (let index = 1; index <= json[result.labels[0]].length; index++) {
+                result.datasets.push({
+                    label: `Próg w cyklu ${index}`,
+                    data: [],
+                    backgroundColor: colors[index - 1]
+                })
+            }
         }
 
         Object.keys(json).forEach(key => {

--- a/frontend/src/pages/FacultyAnalysis/Charts/ThresholdChart.js
+++ b/frontend/src/pages/FacultyAnalysis/Charts/ThresholdChart.js
@@ -16,6 +16,8 @@ export default function ThresholdChart({ faculty, cycle, allowedFields }) {
 
     //converts the result of fetched json to format accepted by chart component
     const convertResult = (json) => {
+        json = GetReducedFields(json, allowedFields)
+
         const result = { labels: Object.keys(json), datasets: [] }
 
         if(typeof json[result.labels[0]] !== "undefined") {
@@ -61,7 +63,7 @@ export default function ThresholdChart({ faculty, cycle, allowedFields }) {
             <CardContent>
                 <div >
                     {/* TODO change data to real data */}
-                    <Bar data={convertResult(GetReducedFields(fakeData, allowedFields))} options={options} />
+                    <Bar data={convertResult(fakeData)} options={options} />
                 </div>
             </CardContent>
 

--- a/frontend/src/pages/FacultyAnalysis/Charts/ThresholdChart.js
+++ b/frontend/src/pages/FacultyAnalysis/Charts/ThresholdChart.js
@@ -39,8 +39,8 @@ export default function ThresholdChart({ faculty, cycle, allowedFields }) {
 
     //TODO usnąć po tym jak będzie możliwosć pobierania
     const fakeData = {
-        informatyka: [960, 960, 960, 960],
-        elektrotechnika: [890, 870, 840, 840],
+        Informatyka: [960, 960, 960, 960],
+        Elektornika: [890, 870, 840, 840],
         telekomunikacja: [920, 900, 890, 880],
         cyberbezpieczeństwo: [950, 940, 940, 938],
         random: [960, 960, 960, 960],

--- a/frontend/src/pages/FacultyAnalysis/Charts/ThresholdChart.js
+++ b/frontend/src/pages/FacultyAnalysis/Charts/ThresholdChart.js
@@ -3,6 +3,7 @@ import { Bar } from 'react-chartjs-2';
 import { Card, CardHeader, CardContent, Typography } from '@material-ui/core'
 import useFetch from '../../../hooks/useFetch';
 import { colors, commonOptions } from './settings'
+import { GetReducedFields } from '../FacultyAnalysis';
 
 const options = {
     ...commonOptions,
@@ -11,7 +12,7 @@ const options = {
 
 
 
-export default function ThresholdChart({ faculty, cycle }) {
+export default function ThresholdChart({ faculty, cycle, allowedFields }) {
 
     //converts the result of fetched json to format accepted by chart component
     const convertResult = (json) => {
@@ -58,7 +59,7 @@ export default function ThresholdChart({ faculty, cycle }) {
             <CardContent>
                 <div >
                     {/* TODO change data to real data */}
-                    <Bar data={convertResult(fakeData)} options={options} />
+                    <Bar data={convertResult(GetReducedFields(fakeData, allowedFields))} options={options} />
                 </div>
             </CardContent>
 

--- a/frontend/src/pages/FacultyAnalysis/Charts/ThresholdChart.js
+++ b/frontend/src/pages/FacultyAnalysis/Charts/ThresholdChart.js
@@ -18,12 +18,14 @@ export default function ThresholdChart({ faculty, cycle, allowedFields }) {
     const convertResult = (json) => {
         const result = { labels: Object.keys(json), datasets: [] }
 
-        for (let index = 1; index <= json[result.labels[0]].length; index++) {
-            result.datasets.push({
-                label: `Próg w cyklu ${index}`,
-                data: [],
-                backgroundColor: colors[index - 1]
-            })
+        if(typeof json[result.labels[0]] !== "undefined") {
+            for (let index = 1; index <= json[result.labels[0]].length; index++) {
+                result.datasets.push({
+                    label: `Próg w cyklu ${index}`,
+                    data: [],
+                    backgroundColor: colors[index - 1]
+                })
+            }
         }
 
         Object.keys(json).forEach(key => {

--- a/frontend/src/pages/FacultyAnalysis/Charts/settings.js
+++ b/frontend/src/pages/FacultyAnalysis/Charts/settings.js
@@ -15,4 +15,8 @@ export const commonOptions = {
             },
         ],
     },
+    //TODO: REMOVE?
+    animation: {
+        duration: 0
+    }
 };

--- a/frontend/src/pages/FacultyAnalysis/FacultyAnalysis.js
+++ b/frontend/src/pages/FacultyAnalysis/FacultyAnalysis.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useEffect } from 'react'
 import PageTitle from '../../components/PageTitle/PageTitle';
 import useFetch from '../../hooks/useFetch';
 import { useState } from 'react';
@@ -12,6 +12,7 @@ import CandidatesNumChart from './Charts/CandidatesNumChart';
 import SelectFieldsComponent from './../../components/SelectFields/SelectFieldsComponent';
 import AveragesMediansChart from './Charts/AveragesMediandsChart';
 import StudentsStatusChart from './Charts/StudentsStatusChart';
+import Cycle2ndChart from './Charts/Cycle2ndChart';
 
 
 export function GetReducedFields(fieldsLiteral, allowedFields) {
@@ -23,10 +24,14 @@ export function GetReducedFields(fieldsLiteral, allowedFields) {
         }, {});
 }
 
+export function GetReducedArray(fieldsArray, allowedFields) {
+    return fieldsArray.filter(arr => allowedFields.includes(arr["name"]));
+}
+
 const FacultyAnalysis = () => {
     var classes = useStyles();
 
-    const [facultiesStudyFields, loading, error] = useFetch('api/backend/fields_of_studies/', [], json => json)
+    const [facultiesStudyFields, loading, error] = useFetch('api/backend/fields_of_studies/', [], json => json);
     // const [faculties, loading, error] = useFetch('api/backend/basic-data/faculty', [], json => json.all)
     const faculties = Object.keys(facultiesStudyFields);
 
@@ -38,16 +43,16 @@ const FacultyAnalysis = () => {
     const [cycle, setCycle] = useState(1);
 
     //TODO change after we get real rest requests
-    //const allFields = facultiesStudyFields[faculties[facultyIdx]];
-    const allFields = [
-        "informatyka",
-        "elektrotechnika",
-        "telekomunikacja",
-        "cyberbezpieczeństwo",
-        "random",
-        "org",
-        "kolejnykierunek"
-    ]
+    const allFields = facultiesStudyFields[faculties[facultyIdx]];
+    // const allFields = [
+    //     "informatyka",
+    //     "elektrotechnika",
+    //     "telekomunikacja",
+    //     "cyberbezpieczeństwo",
+    //     "random",
+    //     "org",
+    //     "kolejnykierunek"
+    // ]
 
     //TODO maybe refactor after we implement GET request
     const [allowedFields, setAllowedFields] = useState(allFields ? allFields : []);
@@ -63,7 +68,7 @@ const FacultyAnalysis = () => {
                     <>
                         <div className={classes.pageTitleContainer}>
                             <Typography className={classes.text} variant="h3" size="sm">
-                                Podsumowanie wydziału {/* TODO jakoś lepiej by to wypadało nazwać  */}
+                                Podsumowanie wydziału {faculties[facultyIdx]} stopień {cycle}
                             </Typography>
                             <div className={classes.formContainer}>
                                 <div className={classes.facultySelector}>
@@ -111,7 +116,10 @@ const FacultyAnalysis = () => {
                                 <CandidatesNumChart faculty={faculties[facultyIdx]} cycle={cycle} allowedFields={allowedFields}/>
                             </Grid>
                             <Grid item xs={12} md={6}>
-                                <LaureateChart faculty={faculties[facultyIdx]} allowedFields={allowedFields}/>
+                                {cycle == 1 ? 
+                                    <LaureateChart faculty={faculties[facultyIdx]} allowedFields={allowedFields}/> :
+                                    <Cycle2ndChart faculty={faculties[facultyIdx]} allowedFields={allowedFields}/>
+                                }
                             </Grid>
                             <Grid item xs={12}>
                                 <ThresholdChart faculty={faculties[facultyIdx]} cycle={cycle} allowedFields={allowedFields}/>

--- a/frontend/src/pages/FacultyAnalysis/FacultyAnalysis.js
+++ b/frontend/src/pages/FacultyAnalysis/FacultyAnalysis.js
@@ -100,7 +100,7 @@ const FacultyAnalysis = () => {
 
                         <Grid container spacing={2}>
                             <Grid item xs={12} md={6}>
-                                <CandidatesNumChart faculty={faculties[facultyIdx]} cycle={cycle} allowedFields={allowedFields}/>
+                                <CandidatesNumChart faculty={faculties[facultyIdx]} cycle={cycle} year={"2020"} allowedFields={allowedFields}/>
                             </Grid>
                             <Grid item xs={12} md={6}>
                                 {cycle == 1 ? 
@@ -112,7 +112,7 @@ const FacultyAnalysis = () => {
                                 <ThresholdChart faculty={faculties[facultyIdx]} cycle={cycle} allowedFields={allowedFields}/>
                             </Grid>
                             <Grid item xs={12} md={6}>
-                                <AveragesMediansChart faculty={faculties[facultyIdx]} cycle={cycle} allowedFields={allowedFields}/>
+                                <AveragesMediansChart faculty={faculties[facultyIdx]} cycle={cycle} year={"2020"} allowedFields={allowedFields}/>
                             </Grid>
                             <Grid item xs={12}>
                                 <StudentsStatusChart faculty={faculties[facultyIdx]} cycle={cycle} year={"2020"} allowedFields={allowedFields}/>

--- a/frontend/src/pages/FacultyAnalysis/FacultyAnalysis.js
+++ b/frontend/src/pages/FacultyAnalysis/FacultyAnalysis.js
@@ -68,7 +68,7 @@ const FacultyAnalysis = () => {
                     <>
                         <div className={classes.pageTitleContainer}>
                             <Typography className={classes.text} variant="h3" size="sm">
-                                Podsumowanie wydziału {faculties[facultyIdx]} stopień {cycle}
+                                Podsumowanie: {faculties[facultyIdx]} stopień {cycle}
                             </Typography>
                             <div className={classes.formContainer}>
                                 <div className={classes.facultySelector}>

--- a/frontend/src/pages/FacultyAnalysis/FacultyAnalysis.js
+++ b/frontend/src/pages/FacultyAnalysis/FacultyAnalysis.js
@@ -31,33 +31,20 @@ export function GetReducedArray(fieldsArray, allowedFields) {
 const FacultyAnalysis = () => {
     var classes = useStyles();
 
-    const [facultiesStudyFields, loading, error] = useFetch('api/backend/fields_of_studies/', [], json => json);
-    // const [faculties, loading, error] = useFetch('api/backend/basic-data/faculty', [], json => json.all)
-    const faculties = Object.keys(facultiesStudyFields);
-
+    const [facultiesStudyFields, loading, error] = useFetch('api/backend/fields_of_studies/', [], json => {
+        return json
+    });
+    
     // trochę tricky, bo zamiast przetrzymywać tu nazwę wydziału przetrzymuję tu numer indeksu w tablicy wydziałów,
     // żeby można było łatwiej przekazywać do potomych komponentów oraz ustawić to jako domyślną wartość w formie
     // w momencie ustalania tego parametru nie mamy jeszcze pobranej listy wydziałów, ale wiemy, że będzie miała co najmniej
     // jeden element oraz będziemy się do niej odwoływać dopiero jak będzie pobrana, czyli loading będzie na false
     const [facultyIdx, setFacultyIdx] = useState(0);
     const [cycle, setCycle] = useState(1);
+    const [allowedFields, setAllowedFields] = useState([]);
 
-    //TODO change after we get real rest requests
+    const faculties = Object.keys(facultiesStudyFields);
     const allFields = facultiesStudyFields[faculties[facultyIdx]];
-    // const allFields = [
-    //     "informatyka",
-    //     "elektrotechnika",
-    //     "telekomunikacja",
-    //     "cyberbezpieczeństwo",
-    //     "random",
-    //     "org",
-    //     "kolejnykierunek"
-    // ]
-
-    //TODO maybe refactor after we implement GET request
-    const [allowedFields, setAllowedFields] = useState(allFields ? allFields : []);
-
-
 
     return (
         <>
@@ -80,7 +67,7 @@ const FacultyAnalysis = () => {
                                             id="faculty-input"
                                             name='faculty'
                                             defaultValue={facultyIdx}
-                                            onChange={e => { setFacultyIdx(e.target.value) }}
+                                            onChange={e => setFacultyIdx(e.target.value)}
                                         >
                                             {
                                                 faculties.map((element, idx) => {
@@ -128,7 +115,7 @@ const FacultyAnalysis = () => {
                                 <AveragesMediansChart faculty={faculties[facultyIdx]} cycle={cycle} allowedFields={allowedFields}/>
                             </Grid>
                             <Grid item xs={12}>
-                                <StudentsStatusChart faculty={faculties[facultyIdx]} cycle={cycle} allowedFields={allowedFields}/>
+                                <StudentsStatusChart faculty={faculties[facultyIdx]} cycle={cycle} year={"2020"} allowedFields={allowedFields}/>
                             </Grid>
                             <Grid item xs={12}>
                                 <FacultyAggregation />

--- a/frontend/src/pages/FacultyAnalysis/FacultyAnalysis.js
+++ b/frontend/src/pages/FacultyAnalysis/FacultyAnalysis.js
@@ -11,6 +11,7 @@ import CandidatesNumChart from './Charts/CandidatesNumChart';
 
 import SelectFieldsComponent from './../../components/SelectFields/SelectFieldsComponent';
 import AveragesMediansChart from './Charts/AveragesMediandsChart';
+import StudentsStatusChart from './Charts/StudentsStatusChart';
 
 
 export function GetReducedFields(fieldsLiteral, allowedFields) {
@@ -107,7 +108,7 @@ const FacultyAnalysis = () => {
 
                         <Grid container spacing={2}>
                             <Grid item xs={12} md={6}>
-                                <CandidatesNumChart faculty={faculties[facultyIdx]} allowedFields={allowedFields}/>
+                                <CandidatesNumChart faculty={faculties[facultyIdx]} cycle={cycle} allowedFields={allowedFields}/>
                             </Grid>
                             <Grid item xs={12} md={6}>
                                 <LaureateChart faculty={faculties[facultyIdx]} allowedFields={allowedFields}/>
@@ -116,12 +117,11 @@ const FacultyAnalysis = () => {
                                 <ThresholdChart faculty={faculties[facultyIdx]} cycle={cycle} allowedFields={allowedFields}/>
                             </Grid>
                             <Grid item xs={12} md={6}>
-                                <AveragesMediansChart faculty={faculties[facultyIdx]} allowedFields={allowedFields}/>
+                                <AveragesMediansChart faculty={faculties[facultyIdx]} cycle={cycle} allowedFields={allowedFields}/>
                             </Grid>
-                            <Grid item xs={12} md={6}>
-                                {/* <LaureateChart faculty={faculties[facultyIdx]} cycle={cycle} /> */}
+                            <Grid item xs={12}>
+                                <StudentsStatusChart faculty={faculties[facultyIdx]} cycle={cycle} allowedFields={allowedFields}/>
                             </Grid>
-
                             <Grid item xs={12}>
                                 <FacultyAggregation />
                             </Grid>

--- a/frontend/src/pages/FacultyAnalysis/FacultyAnalysis.js
+++ b/frontend/src/pages/FacultyAnalysis/FacultyAnalysis.js
@@ -25,7 +25,9 @@ export function GetReducedFields(fieldsLiteral, allowedFields) {
 const FacultyAnalysis = () => {
     var classes = useStyles();
 
-    const [faculties, loading, error] = useFetch('api/backend/basic-data/faculty', [], json => json.all)
+    const [facultiesStudyFields, loading, error] = useFetch('api/backend/fields_of_studies/', [], json => json)
+    // const [faculties, loading, error] = useFetch('api/backend/basic-data/faculty', [], json => json.all)
+    const faculties = Object.keys(facultiesStudyFields);
 
     // trochę tricky, bo zamiast przetrzymywać tu nazwę wydziału przetrzymuję tu numer indeksu w tablicy wydziałów,
     // żeby można było łatwiej przekazywać do potomych komponentów oraz ustawić to jako domyślną wartość w formie
@@ -34,7 +36,8 @@ const FacultyAnalysis = () => {
     const [facultyIdx, setFacultyIdx] = useState(0);
     const [cycle, setCycle] = useState(1);
 
-    //TODO get them from GET request
+    //TODO change after we get real rest requests
+    //const allFields = facultiesStudyFields[faculties[facultyIdx]];
     const allFields = [
         "informatyka",
         "elektrotechnika",
@@ -50,7 +53,6 @@ const FacultyAnalysis = () => {
 
 
 
-
     return (
         <>
             {
@@ -58,7 +60,6 @@ const FacultyAnalysis = () => {
                     <p>loading</p> // TODO zmienić na spinner
                     :
                     <>
-
                         <div className={classes.pageTitleContainer}>
                             <Typography className={classes.text} variant="h3" size="sm">
                                 Podsumowanie wydziału {/* TODO jakoś lepiej by to wypadało nazwać  */}
@@ -106,16 +107,16 @@ const FacultyAnalysis = () => {
 
                         <Grid container spacing={2}>
                             <Grid item xs={12} md={6}>
-                                <CandidatesNumChart faculty={faculties[facultyIdx]} cycle={cycle} allowedFields={allowedFields}/>
+                                <CandidatesNumChart faculty={faculties[facultyIdx]} allowedFields={allowedFields}/>
                             </Grid>
                             <Grid item xs={12} md={6}>
-                                <LaureateChart faculty={faculties[facultyIdx]} cycle={cycle} />
+                                <LaureateChart faculty={faculties[facultyIdx]} allowedFields={allowedFields}/>
                             </Grid>
                             <Grid item xs={12}>
-                                <ThresholdChart faculty={faculties[facultyIdx]} cycle={cycle} />
+                                <ThresholdChart faculty={faculties[facultyIdx]} cycle={cycle} allowedFields={allowedFields}/>
                             </Grid>
                             <Grid item xs={12} md={6}>
-                                <AveragesMediansChart faculty={faculties[facultyIdx]} cycle={cycle} allowedFields={allowedFields}/>
+                                <AveragesMediansChart faculty={faculties[facultyIdx]} allowedFields={allowedFields}/>
                             </Grid>
                             <Grid item xs={12} md={6}>
                                 {/* <LaureateChart faculty={faculties[facultyIdx]} cycle={cycle} /> */}

--- a/frontend/src/pages/FacultyAnalysis/FacultyAnalysis.js
+++ b/frontend/src/pages/FacultyAnalysis/FacultyAnalysis.js
@@ -7,7 +7,20 @@ import ThresholdChart from './Charts/ThresholdChart';
 import useStyles from "./styles";
 import LaureateChart from './Charts/LaureateChart';
 import FacultyAggregation from './Tables/FacultyAggregation';
+import CandidatesNumChart from './Charts/CandidatesNumChart';
 
+import SelectFieldsComponent from './../../components/SelectFields/SelectFieldsComponent';
+import AveragesMediansChart from './Charts/AveragesMediandsChart';
+
+
+export function GetReducedFields(fieldsLiteral, allowedFields) {
+    return Object.keys(fieldsLiteral)
+        .filter(key => allowedFields.includes(key))
+        .reduce((obj,key) => {
+            obj[key] = fieldsLiteral[key];
+            return obj;
+        }, {});
+}
 
 const FacultyAnalysis = () => {
     var classes = useStyles();
@@ -20,6 +33,22 @@ const FacultyAnalysis = () => {
     // jeden element oraz będziemy się do niej odwoływać dopiero jak będzie pobrana, czyli loading będzie na false
     const [facultyIdx, setFacultyIdx] = useState(0);
     const [cycle, setCycle] = useState(1);
+
+    //TODO get them from GET request
+    const allFields = [
+        "informatyka",
+        "elektrotechnika",
+        "telekomunikacja",
+        "cyberbezpieczeństwo",
+        "random",
+        "org",
+        "kolejnykierunek"
+    ]
+
+    //TODO maybe refactor after we implement GET request
+    const [allowedFields, setAllowedFields] = useState(allFields ? allFields : []);
+
+
 
 
     return (
@@ -71,13 +100,27 @@ const FacultyAnalysis = () => {
                             </div>
                         </div>
 
+                        <div>
+                            <SelectFieldsComponent fields={allFields} setFields={setAllowedFields}/>
+                        </div>
+
                         <Grid container spacing={2}>
+                            <Grid item xs={12} md={6}>
+                                <CandidatesNumChart faculty={faculties[facultyIdx]} cycle={cycle} allowedFields={allowedFields}/>
+                            </Grid>
                             <Grid item xs={12} md={6}>
                                 <LaureateChart faculty={faculties[facultyIdx]} cycle={cycle} />
                             </Grid>
                             <Grid item xs={12}>
                                 <ThresholdChart faculty={faculties[facultyIdx]} cycle={cycle} />
                             </Grid>
+                            <Grid item xs={12} md={6}>
+                                <AveragesMediansChart faculty={faculties[facultyIdx]} cycle={cycle} allowedFields={allowedFields}/>
+                            </Grid>
+                            <Grid item xs={12} md={6}>
+                                {/* <LaureateChart faculty={faculties[facultyIdx]} cycle={cycle} /> */}
+                            </Grid>
+
                             <Grid item xs={12}>
                                 <FacultyAggregation />
                             </Grid>


### PR DESCRIPTION
###  CHA 65
Wykres przedstawiający liczbę kandydatów na miejsce - `CandidatesNumChart.js`
Zbieranie danych przygotowane pod requesta POST `'/api/backend/fields-of-study-candidates-per-place/'`, gdzie przekazujemy payloada: `const payload = {"year":year, "degree":cycle, "faculty":faculty}`

### CHA 67
Wykres przedstawiający średnie oraz mediany na kierunkach - `AveragesMediansChart.js`
Zbieranie danych przygotowane pod requesta GET `'/api/backend/aam/${faculty}+${year}/'`

### CHA 68
Wykres przedstawiający liczbę kandydatów według statusu - `StudentsStatusChart.js`
Zbieranie danych przygotowane pod requesta GET `'/api/backend/status-distribution/${year}/${faculty}/${cycle}/'`


### Dodatkowe funkcjonalności
1. `useFetchPost` - hook utworzony na podstawie `useFetch` ale korzysta z metody POST i moze przekazywać payloada.
2. `SelectFieldsComponent` - komponent, który pozwala na wybieranie aktywnych kierunków dla danego wydziału. Sam layout jest jeszcze niedopracowany, ale poprawię go gdy będziemy mieli już przygotowanych więcej kierunków na wydział.
3. Zmieniłem sposób zdobywania wydziałów i kierunków w `FacultyAnalysis` - teraz pobiera pełną listę wydziałów i kierunków a następnie je filtruje w zależności od aktualnie wybranego wydziału.
4. W `frontend/src/pages/FacultyAnalysis/Charts/settings.js` dodałem `animation:{duration:0}`, które całowicie usuwa animacje wykresów. Bez tego każde zaznaczenie kierunku skutkowało wykonaniem animacji, co uznałem za zbyt rozpraszające.
5. Drobna poprawka kodu, żeby linter pokazywał mniej warningów.