### PR TITLE
CHA-61 current recruitment aggregate endpoint

### DIFF
--- a/backend/urls.py
+++ b/backend/urls.py
@@ -10,6 +10,7 @@ from backend.views import (ActualFacultyThreshold, AddFacultyView,
                            RecruitmentResultFieldsOfStudyListView,
                            RecruitmentResultListView,
                            RecruitmentResultOverviewListView,
+                           RecruitmentStatusAggregateListView,
                            StatusDistributionView, UploadFieldsOfStudyView,
                            UploadView)
 
@@ -64,5 +65,10 @@ urlpatterns = [
     path(
         r'actual_recruitment_faculty_threshold/faculty=<faculty>'
         r'&cycle=<degree>/',
-        ActualFacultyThreshold.as_view(), name='actual_threshold')
+        ActualFacultyThreshold.as_view(), name='actual_threshold'),
+    re_path(
+        r'^actual_recruitment_faculty_aggregation/faculty=(?P<faculty>.+)'
+        r'&cycle=(?P<cycle>.+)$',
+        RecruitmentStatusAggregateListView.as_view(),
+        name='actual_recruitment')
 ]


### PR DESCRIPTION
Endpoint agregujący informacje o statusie bieżącej rekrutacji na wydziale

Ścieżka: **/api/backend/actual_recruitment_faculty_aggregation/faculty=<nazwa wydziału>&cycle=<stopień studiów>**
Metoda HTTP: **GET**

Odpowiedź to tablica pasujących obiektów:

```json
{
        "year": 2019,
        "field_of_study": "Informatyka",
        "recruitment_round": 1,
        "treshold": 950.0,
        "mean": 951.0,
        "median": 950.0,
        "candidates_no": 3,
        "laureate_no": 1,
        "signed_in": 2,
        "not_signed_in": 1,
        "resigned": 1,
        "under_treshold": 2
 }
```