### PR TITLE
Feature/cha 86 status distribution over the years

### DIFF
--- a/backend/urls.py
+++ b/backend/urls.py
@@ -10,7 +10,7 @@ from backend.views import (ActualFacultyThreshold, AddFacultyView,
                            RecruitmentResultFieldsOfStudyListView,
                            RecruitmentResultListView,
                            RecruitmentResultOverviewListView,
-                           RecruitmentStatusAggregateListView,
+                           RecruitmentStatusAggregateListView, StatusDistributionOverTheYearsView,
                            StatusDistributionView, UploadFieldsOfStudyView,
                            UploadView)
 
@@ -75,4 +75,17 @@ urlpatterns = [
         r'&cycle=(?P<cycle>.+)$',
         RecruitmentStatusAggregateListView.as_view(),
         name='actual_recruitment'),
+
+    path('status-distribution-over-the-years/',
+         StatusDistributionOverTheYearsView.as_view(),
+         name='status-distribution-over-the-years'),
+    path('status-distribution-over-the-years/<faculty>/',
+         StatusDistributionOverTheYearsView.as_view(),
+         name='status-distribution-over-the-years'),
+    path('status-distribution-over-the-years/<faculty>/<field_of_study>/',
+         StatusDistributionOverTheYearsView.as_view(),
+         name='status-distribution-over-the-years'),
+    path('status-distribution-over-the-years/<faculty>/<field_of_study>/<degree>/',
+         StatusDistributionOverTheYearsView.as_view(),
+         name='status-distribution-over-the-years'),
 ]

--- a/backend/urls.py
+++ b/backend/urls.py
@@ -10,7 +10,8 @@ from backend.views import (ActualFacultyThreshold, AddFacultyView,
                            RecruitmentResultFieldsOfStudyListView,
                            RecruitmentResultListView,
                            RecruitmentResultOverviewListView,
-                           RecruitmentStatusAggregateListView, StatusDistributionOverTheYearsView,
+                           RecruitmentStatusAggregateListView,
+                           StatusDistributionOverTheYearsView,
                            StatusDistributionView, UploadFieldsOfStudyView,
                            UploadView)
 
@@ -85,7 +86,8 @@ urlpatterns = [
     path('status-distribution-over-the-years/<faculty>/<field_of_study>/',
          StatusDistributionOverTheYearsView.as_view(),
          name='status-distribution-over-the-years'),
-    path('status-distribution-over-the-years/<faculty>/<field_of_study>/<degree>/',
+    path('status-distribution-over-the-years/' +
+         '<faculty>/<field_of_study>/<degree>/',
          StatusDistributionOverTheYearsView.as_view(),
          name='status-distribution-over-the-years'),
 ]

--- a/backend/views.py
+++ b/backend/views.py
@@ -564,8 +564,8 @@ class StatusDistributionOverTheYearsView(APIView):
             field_of_study: str = None,
             degree: str = None) -> Response:
         try:
-            tmp = RecruitmentResult.objects
-                           
+            tmp: Any = RecruitmentResult.objects
+
             if faculty:
                 tmp = tmp.filter(
                     recruitment__field_of_study__faculty__name=faculty)
@@ -581,7 +581,6 @@ class StatusDistributionOverTheYearsView(APIView):
                 'result')
                 .annotate(total=Count('result')).
                 order_by('total'))
-
 
             result: Dict[Any, Any] = {"all": {}}
             for d in tmp:

--- a/backend/views.py
+++ b/backend/views.py
@@ -557,6 +557,61 @@ class StatusDistributionView(APIView):
             )
 
 
+class StatusDistributionOverTheYearsView(APIView):
+    permission_classes = (IsAuthenticated,)
+
+    def get(self, request: Request, faculty: str = None,
+            field_of_study: str = None,
+            degree: str = None) -> Response:
+        try:
+            tmp = RecruitmentResult.objects
+                           
+            if faculty:
+                tmp = tmp.filter(
+                    recruitment__field_of_study__faculty__name=faculty)
+            if field_of_study:
+                tmp = tmp.filter(
+                    recruitment__field_of_study__name=field_of_study)
+            if degree:
+                tmp = tmp.filter(recruitment__field_of_study__degree=degree)
+
+            tmp = (tmp.values(
+                'recruitment__field_of_study__name',
+                'recruitment__year',
+                'result')
+                .annotate(total=Count('result')).
+                order_by('total'))
+
+
+            result: Dict[Any, Any] = {"all": {}}
+            for d in tmp:
+                fof = d['recruitment__field_of_study__name']
+                round = d['recruitment__year']
+                rstatus = d['result']
+                total = d['total']
+
+                if fof not in result:
+                    result[fof] = {"all": {}}
+                if round not in result[fof]:
+                    result[fof][round] = {}
+                if rstatus not in result["all"]:
+                    result["all"][rstatus] = 0
+                if rstatus not in result[fof]["all"]:
+                    result[fof]["all"][rstatus] = 0
+
+                result[fof][round][rstatus] = total
+                result["all"][rstatus] += total
+                result[fof]["all"][rstatus] += total
+
+            return Response(result, status=status.HTTP_200_OK)
+        except Exception as e:
+            print(e)
+            return Response(
+                {"problem": str(e)},
+                status=status.HTTP_503_SERVICE_UNAVAILABLE
+            )
+
+
 def get_median(values: django.db.models.QuerySet[RecruitmentResult]) -> float:
 
     sorted_list = sorted(list(map(lambda x: x.points, values)))

--- a/backend/views.py
+++ b/backend/views.py
@@ -582,25 +582,19 @@ class StatusDistributionOverTheYearsView(APIView):
                 .annotate(total=Count('result')).
                 order_by('total'))
 
-            result: Dict[Any, Any] = {"all": {}}
+            result: Dict[Any, Any] = {}
             for d in tmp:
                 fof = d['recruitment__field_of_study__name']
-                round = d['recruitment__year']
+                year = d['recruitment__year']
                 rstatus = d['result']
                 total = d['total']
 
                 if fof not in result:
-                    result[fof] = {"all": {}}
-                if round not in result[fof]:
-                    result[fof][round] = {}
-                if rstatus not in result["all"]:
-                    result["all"][rstatus] = 0
-                if rstatus not in result[fof]["all"]:
-                    result[fof]["all"][rstatus] = 0
+                    result[fof] = {}
+                if year not in result[fof]:
+                    result[fof][year] = {}
 
-                result[fof][round][rstatus] = total
-                result["all"][rstatus] += total
-                result[fof]["all"][rstatus] += total
+                result[fof][year][rstatus] = total
 
             return Response(result, status=status.HTTP_200_OK)
         except Exception as e:


### PR DESCRIPTION
Endpoint do uzyskiwania rozkładu statusów dla kierunków na przestrzeni lat

Teraz idąc pod adres:
- `api/backend/status-distribution-over-the-years/` otrzymamy JSONa dotyczącego wszystkich kierunków na AGH
- `api/backend/status-distribution-over-the-years/faculty/` dotyczącego kierunków na danym wydziale
- `api/backend/status-distribution-over-the-years/faculty/fof/` dotyczącego konkretnej nazwy kierunku
- `api/backend/status-distribution-over-the-years/faculty/fof/degree/` dotyczącego konkretnego kierunku

Dane są podzielone na kierunki i lata.

Wzór JSONa:
```js
{
  kierunek1: {
    rok1: {
      status1: liczba1,
      status2: liczba2,
      ...
    },
    rok2: {
      ...
    },
    ...
  },
  kierunek2: {
    ...
  },
}
```