### PR TITLE
CHA-80 recruitment result overview more ino

### DIFF
--- a/backend/filters.py
+++ b/backend/filters.py
@@ -25,8 +25,8 @@ class FieldOfStudyListFilters:
             field_of_study_filters["name"] = self.name_filter
 
         if self.degree_filter is not None:
-            field_of_study_filters["degree__in"] = \
-                (6, 7) if self.degree_filter == 1 else 8
+            field_of_study_filters["degree"] = \
+                self.degree_filter
 
         return field_of_study_filters
 

--- a/backend/serializers.py
+++ b/backend/serializers.py
@@ -1,6 +1,6 @@
 from typing import Any, Dict, Optional
 
-from django.db.models import Model
+from django.db.models import Manager, Model
 from django.db.models.aggregates import Avg, Max, Min
 from rest_framework import serializers
 
@@ -284,36 +284,98 @@ class RecruitmentResultOverviewSerializer(serializers.ModelSerializer[Any]):
         ReadOnlyField(source='field_of_study.faculty.name')
     field_of_study = serializers. \
         ReadOnlyField(source='field_of_study.name')
-    candidates_count = serializers.SerializerMethodField()
+    candidates_per_place = serializers.SerializerMethodField()
     signed_candidates_count = serializers.SerializerMethodField()
+    unregistered_candidates_count = serializers.SerializerMethodField()
     contest_laureates_count = serializers.SerializerMethodField()
+    threshold = serializers.SerializerMethodField()
+    mean = serializers.SerializerMethodField()
+    median = serializers.SerializerMethodField()
 
     class Meta:
         model = Recruitment
         fields = ('field_of_study', 'faculty', 'degree',
-                  'year', 'round', 'candidates_count',
+                  'year', 'round', 'candidates_per_place',
                   'signed_candidates_count',
-                  'contest_laureates_count')
+                  'unregistered_candidates_count',
+                  'contest_laureates_count', 'threshold',
+                  'mean', 'median')
+
+    def get_recruitments(self, obj: Recruitment) -> Manager[Recruitment]:
+        return Recruitment.objects.filter(
+            field_of_study=obj.field_of_study,
+            year=obj.year
+        )
 
     def get_degree(self, obj: Recruitment) -> Optional[str]:
         return str(obj.field_of_study.degree)
 
-    def get_candidates_count(self, obj: Recruitment) -> int:
-        return RecruitmentResult.objects.filter(
-            recruitment=obj).values_list(
+    def get_candidates_per_place(self, obj: Recruitment) -> Any:
+        candidates = RecruitmentResult.objects.filter(
+            recruitment__in=self.get_recruitments(obj)).values_list(
             'student', flat=True).distinct().count()
+        places = FieldOfStudyPlacesLimit.objects.filter(
+            field_of_study=obj.field_of_study,
+            year=obj.year
+        )
+        if len(places) > 0:
+            return candidates / places[0].places
+        return None
 
     def get_signed_candidates_count(self, obj: Recruitment) -> int:
         return RecruitmentResult.objects.filter(
-            recruitment=obj, result='Signed').values_list(
+            recruitment__in=self.get_recruitments(obj),
+            result='signed').values_list(
+            'student', flat=True).distinct().count()
+
+    def get_unregistered_candidates_count(self, obj: Recruitment) -> int:
+        return RecruitmentResult.objects.filter(
+            recruitment__in=self.get_recruitments(obj),
+            result='unregistered').values_list(
             'student', flat=True).distinct().count()
 
     def get_contest_laureates_count(self, obj: Recruitment) -> int:
         candidates = Candidate.objects.exclude(
             contest__isnull=True).exclude(contest__exact='')
         return RecruitmentResult.objects.filter(
-            recruitment=obj, student__in=candidates).values_list(
+            recruitment__in=self.get_recruitments(obj),
+            student__in=candidates).values_list(
             'student', flat=True).distinct().count()
+
+    def get_threshold(self, obj: Recruitment) -> Any:
+        recruitment_results = RecruitmentResult.objects.filter(
+            recruitment__in=self.get_recruitments(obj),
+            result='signed'
+        )
+        if recruitment_results:
+            result = recruitment_results.aggregate(Min('points')).get(
+                'points__min')
+            return result
+        return None
+
+    def get_mean(self, obj: Recruitment) -> Any:
+        recruitment_results = RecruitmentResult.objects.filter(
+            recruitment__in=self.get_recruitments(obj)
+        )
+        if recruitment_results:
+            result = recruitment_results.aggregate(Avg('points')).get(
+                'points__avg')
+            return result
+        return None
+
+    def get_median(self, obj: Recruitment) -> Any:
+        recruitment_results = RecruitmentResult.objects.filter(
+            recruitment__in=self.get_recruitments(obj)
+        )
+        count = recruitment_results.count()
+        ordered_results = recruitment_results.values_list(
+            'points', flat=True).order_by('points')
+        if count == 0:
+            return None
+        if count % 2 == 0:
+            return (ordered_results[int(count / 2)] +
+                    ordered_results[int(count / 2) + 1]) / 2
+        return ordered_results[int(count / 2)]
 
 
 class UploadFieldOfStudySerializer(serializers.Serializer[Any]):

--- a/backend/serializers.py
+++ b/backend/serializers.py
@@ -334,7 +334,12 @@ class RecruitmentResultOverviewSerializer(serializers.ModelSerializer[Any]):
             result='unregistered').values_list(
             'student', flat=True).distinct().count()
 
-    def get_contest_laureates_count(self, obj: Recruitment) -> int:
+    def get_contest_laureates_count(self, obj: Recruitment) -> Any:
+        degree = self.get_degree(obj)
+        if degree is not None:
+            degree_value: int = int(degree)
+            if degree_value == 2:
+                return None
         candidates = Candidate.objects.exclude(
             contest__isnull=True).exclude(contest__exact='')
         return RecruitmentResult.objects.filter(

--- a/backend/serializers.py
+++ b/backend/serializers.py
@@ -319,7 +319,7 @@ class RecruitmentResultOverviewSerializer(serializers.ModelSerializer[Any]):
             year=obj.year
         )
         if len(places) > 0:
-            return candidates / places[0].places
+            return round(candidates / places[0].places, 2)
         return None
 
     def get_signed_candidates_count(self, obj: Recruitment) -> int:
@@ -370,8 +370,12 @@ class RecruitmentResultOverviewSerializer(serializers.ModelSerializer[Any]):
         count = recruitment_results.count()
         ordered_results = recruitment_results.values_list(
             'points', flat=True).order_by('points')
-        if count == 0:
+        if count == 0 or len(ordered_results) == 0:
             return None
+        if count == 1:
+            return ordered_results[0]
+        if count == 2:
+            return (ordered_results[0] + ordered_results[1]) / 2
         if count % 2 == 0:
             return (ordered_results[int(count / 2)] +
                     ordered_results[int(count / 2) + 1]) / 2

--- a/backend/urls.py
+++ b/backend/urls.py
@@ -11,8 +11,8 @@ from backend.views import (ActualFacultyThreshold, AddFacultyView,
                            RecruitmentResultListView,
                            RecruitmentResultOverviewListView,
                            RecruitmentStatusAggregateListView,
-                           StatusDistributionView, UploadFieldsOfStudyView,
-                           UploadView)
+                           RecruitmentYears, StatusDistributionView,
+                           UploadFieldsOfStudyView, UploadView)
 
 app_name = 'backend'
 
@@ -75,4 +75,6 @@ urlpatterns = [
         r'&cycle=(?P<cycle>.+)$',
         RecruitmentStatusAggregateListView.as_view(),
         name='actual_recruitment'),
+    path('available-years/', RecruitmentYears.as_view(),
+         name='available_years')
 ]

--- a/backend/views.py
+++ b/backend/views.py
@@ -71,15 +71,20 @@ class RecruitmentResultOverviewListView(generics.ListAPIView):
         for key, grp in groupby(sorted(data, key=grouper), grouper):
             temp_dict = dict(zip(
                 ['field_of_study', 'faculty', 'year', 'degree'], key))
-            temp_dict["candidates_count"] = 0
-            temp_dict["signed_candidates_count"] = 0
-            temp_dict["contest_laureates_count"] = 0
-            for item in grp:
-                temp_dict["candidates_count"] += item["candidates_count"]
-                temp_dict["signed_candidates_count"] += \
-                    item["signed_candidates_count"]
-                temp_dict["contest_laureates_count"] += \
-                    item["contest_laureates_count"]
+
+            item = list(grp)[0]
+            temp_dict["candidates_per_place"] = (
+                item["candidates_per_place"])
+            temp_dict["contest_laureates_count"] = (
+                item["contest_laureates_count"])
+            temp_dict["threshold"] = item["threshold"]
+            temp_dict["mean"] = item["mean"]
+            temp_dict["median"] = item["median"]
+            temp_dict["signed_candidates_count"] = (
+                item["signed_candidates_count"])
+            temp_dict["unregistered_candidates_count"] = (
+                item["unregistered_candidates_count"])
+
             result.append(temp_dict)
         return sorted(result, key=itemgetter('year'), reverse=True)
 

--- a/backend/views.py
+++ b/backend/views.py
@@ -1,6 +1,4 @@
 import datetime
-from itertools import groupby
-from operator import itemgetter
 from typing import Any, Dict, List
 
 import django.db.models
@@ -64,34 +62,6 @@ class RecruitmentResultOverviewListView(generics.ListAPIView):
 
         return Recruitment.objects.filter(**filters) \
             if len(filters) > 0 else Recruitment.objects.all()
-
-    def merge_recruitments(self, data: List[Any]) -> List[Any]:
-        grouper = itemgetter('field_of_study', 'faculty', 'year', 'degree')
-        result = []
-        for key, grp in groupby(sorted(data, key=grouper), grouper):
-            temp_dict = dict(zip(
-                ['field_of_study', 'faculty', 'year', 'degree'], key))
-
-            item = list(grp)[0]
-            temp_dict["candidates_per_place"] = (
-                item["candidates_per_place"])
-            temp_dict["contest_laureates_count"] = (
-                item["contest_laureates_count"])
-            temp_dict["threshold"] = item["threshold"]
-            temp_dict["mean"] = item["mean"]
-            temp_dict["median"] = item["median"]
-            temp_dict["signed_candidates_count"] = (
-                item["signed_candidates_count"])
-            temp_dict["unregistered_candidates_count"] = (
-                item["unregistered_candidates_count"])
-
-            result.append(temp_dict)
-        return sorted(result, key=itemgetter('year'), reverse=True)
-
-    def list(self, request: Request, *args: Any, **kwargs: Any) -> Response:
-        queryset = self.get_queryset()
-        serializer = self.get_serializer(queryset, many=True)
-        return Response(self.merge_recruitments(serializer.data))
 
     def post(self, request: Request,
              *args: List[Any], **kwargs: Dict[Any, Any]) -> Response:

--- a/backend/views.py
+++ b/backend/views.py
@@ -608,3 +608,18 @@ class ActualFacultyThreshold(APIView):
         except Exception as e:
             print(e)
             return Response(status=status.HTTP_503_SERVICE_UNAVAILABLE)
+
+
+class RecruitmentYears(APIView):
+    permission_classes = (IsAuthenticated,)
+
+    def get(self, request: Request) -> Response:
+        try:
+            recruitments = Recruitment.objects.values_list(
+                'year',
+                flat=True).distinct()
+            print(recruitments)
+            return Response(recruitments)
+        except Exception as e:
+            print(e)
+            return Response(status=status.HTTP_503_SERVICE_UNAVAILABLE)


### PR DESCRIPTION
Dodałem więcej informacji do podsumowania rekrutacji na kierunku

Metoda HTTP: **POST**
Ścieżka: **/api/backend/recruitment-result-overview/**

Filtry:

```json
{
    "year":"2019",
    "faculty":"WIET",
    "field_of_study":"Informatyka",
    "study_cycle":"1"
}
```

Odpowiedź składa się z pasujących obiektów:

```json
    {
        "field_of_study": "Informatyka",
        "faculty": "WIET",
        "degree": "1",
        "year": 2019,
        "round": 1,
        "candidates_per_place": 0.02,
        "signed_in": 2,
        "resigned": 1,
        "not_signed_in": 0,
        "under_treshold": 0,
        "contest_laureates_count": 2,
        "threshold": 920.0,
        "mean": 947.25,
        "median": 974.5
    }
```

Dodałem endpoint zwracający lata rekrutacji:
Metoda HTTP: **GET**
Ścieżka: **/api/backend/available-years/**

Przykładowa odpowiedź:
```
[
    2018,
    2019,
    2020
]
```
