### PR TITLE
Feature/cha 96 field conversion over the years

### DIFF
--- a/backend/urls.py
+++ b/backend/urls.py
@@ -1,7 +1,8 @@
 from django.urls import path, re_path
 
 from backend.views import (ActualFacultyThreshold, AddFacultyView,
-                           AddFieldOfStudy, AvgAndMedOfFields, CompareFields, FieldConversionOverTheYearsView,
+                           AddFieldOfStudy, AvgAndMedOfFields, CompareFields,
+                           FieldConversionOverTheYearsView,
                            FieldOfStudyCandidatesPerPlaceListView,
                            FieldOfStudyContestLaureatesCountView, GetBasicData,
                            GetFacultiesView, GetFieldsOfStudy,

--- a/backend/urls.py
+++ b/backend/urls.py
@@ -1,7 +1,7 @@
 from django.urls import path, re_path
 
 from backend.views import (ActualFacultyThreshold, AddFacultyView,
-                           AddFieldOfStudy, AvgAndMedOfFields, CompareFields,
+                           AddFieldOfStudy, AvgAndMedOfFields, CompareFields, FieldConversionOverTheYearsView,
                            FieldOfStudyCandidatesPerPlaceListView,
                            FieldOfStudyContestLaureatesCountView, GetBasicData,
                            GetFacultiesView, GetFieldsOfStudy,
@@ -75,4 +75,14 @@ urlpatterns = [
         r'&cycle=(?P<cycle>.+)$',
         RecruitmentStatusAggregateListView.as_view(),
         name='actual_recruitment'),
+
+    path('field-conversion-over-the-years/',
+         FieldConversionOverTheYearsView.as_view(),
+         name='field-conversion'),
+    path('field-conversion-over-the-years/<faculty>/',
+         FieldConversionOverTheYearsView.as_view(),
+         name='field-conversion'),
+    path('field-conversion-over-the-years/<faculty>/<field_of_study>/',
+         FieldConversionOverTheYearsView.as_view(),
+         name='field-conversion'),
 ]

--- a/backend/views.py
+++ b/backend/views.py
@@ -662,7 +662,7 @@ class FieldConversionOverTheYearsView(APIView):
                 'recruitment__year'
             )
 
-            result = {}
+            result: Dict[Any,Any] = {}
             for rr in rrs:
                 try:
                     faculty_name = rr.recruitment.field_of_study.faculty.name

--- a/backend/views.py
+++ b/backend/views.py
@@ -662,7 +662,7 @@ class FieldConversionOverTheYearsView(APIView):
                 'recruitment__year'
             )
 
-            result: Dict[Any,Any] = {}
+            result: Dict[Any, Any] = {}
             for rr in rrs:
                 try:
                     faculty_name = rr.recruitment.field_of_study.faculty.name


### PR DESCRIPTION
Endpoint do odpytywania ile osób kontynuuje naukę na studiach 2. st. na jakimś kierunku, a ile skądś przychodzi na przestrzeni lat
Teraz idąc pod adres:
- `api/backend/field-conversion-over-the-years/` otrzymamy JSONa dotyczącego wszystkich kierunków na AGH
- `api/backend/field-conversion-over-the-years/faculty/` dotyczącego kierunków na danym wydziale
- `api/backend/field-conversion-over-the-years/faculty/fof/` dotyczącego konkretnego kierunku

Dane są podzielone na kierunki i lata.

Wzór JSONa:
```js
{
  kierunek1: {
    rok1: {
      "from-inside": liczba,
      "from-outside": liczba
      },
    rok2: {
      ...
    },
    ...
  },
  kierunek2: {
    ...
  },
}
```