### PR TITLE
CHA-{53,54} Added endpoint and fixed another

### DIFF
--- a/backend/urls.py
+++ b/backend/urls.py
@@ -2,6 +2,7 @@ from django.urls import path, re_path
 
 from backend.views import (ActualFacultyThreshold, AddFacultyView,
                            AddFieldOfStudy, AvgAndMedOfFields, CompareFields,
+                           FacultyThreshold,
                            FieldOfStudyCandidatesPerPlaceListView,
                            FieldOfStudyContestLaureatesCountView, GetBasicData,
                            GetFacultiesView, GetFieldsOfStudy,
@@ -12,7 +13,7 @@ from backend.views import (ActualFacultyThreshold, AddFacultyView,
                            RecruitmentResultOverviewListView,
                            RecruitmentStatusAggregateListView,
                            StatusDistributionView, UploadFieldsOfStudyView,
-                           UploadView, FacultyThreshold)
+                           UploadView)
 
 app_name = 'backend'
 

--- a/backend/urls.py
+++ b/backend/urls.py
@@ -12,7 +12,7 @@ from backend.views import (ActualFacultyThreshold, AddFacultyView,
                            RecruitmentResultOverviewListView,
                            RecruitmentStatusAggregateListView,
                            StatusDistributionView, UploadFieldsOfStudyView,
-                           UploadView)
+                           UploadView, FacultyThreshold)
 
 app_name = 'backend'
 
@@ -36,7 +36,7 @@ urlpatterns = [
          UploadFieldsOfStudyView.as_view(),
          name='upload_fields_of_study'),
     path('faculties/', GetFacultiesView.as_view(), name='faculties'),
-    path('fields_of_studies/',
+    path('fields_of_studies/<degree>/',
          GetFieldsOfStudy.as_view(),
          name='fields_of_studies'),
     path('add/faculty', AddFacultyView.as_view(), name='add_faculty'),
@@ -75,4 +75,6 @@ urlpatterns = [
         r'&cycle=(?P<cycle>.+)$',
         RecruitmentStatusAggregateListView.as_view(),
         name='actual_recruitment'),
+    path('faculty_threshold/<mode>/<degree>/<int:n>/<int:year>',
+         FacultyThreshold.as_view(), name='faculty_threshold')
 ]

--- a/backend/urls.py
+++ b/backend/urls.py
@@ -77,7 +77,7 @@ urlpatterns = [
         RecruitmentStatusAggregateListView.as_view(),
         name='actual_recruitment'),
     path('faculty_threshold/<mode>/<degree>/<int:n>/<int:year>',
-         FacultyThreshold.as_view(), name='faculty_threshold')
+         FacultyThreshold.as_view(), name='faculty_threshold'),
     path('laureate_stats/<int:n>/<int:year>',
          GetMostLaureate.as_view(), name="laureate_stats"),
     path('faculty_popularity/<str:pop_type>/<str:degree>/<int:n>/<int:year>/',

--- a/backend/views.py
+++ b/backend/views.py
@@ -255,9 +255,9 @@ class GetFacultiesView(APIView):
 
 
 class GetFieldsOfStudy(APIView):
-    def get(self, request: Request) -> Response:
+    def get(self, request: Request, degree: str) -> Response:
         result: Dict[str, List[str]] = {}
-        for field in FieldOfStudy.objects.all():
+        for field in FieldOfStudy.objects.filter(degree=degree):
             if field.faculty.name in result:
                 result[field.faculty.name].append(field.name)
             else:
@@ -633,3 +633,29 @@ class ActualFacultyThreshold(APIView):
         except Exception as e:
             print(e)
             return Response(status=status.HTTP_503_SERVICE_UNAVAILABLE)
+
+
+class FacultyThreshold(APIView):
+    permission_classes = (IsAuthenticated,)
+
+    def get(
+            self, request: Request, mode: str,
+            degree: str, n: int, year: int) -> Response:
+        try:
+            result: Dict[str, float] = {}
+            for field in FieldOfStudy.objects.filter(degree=degree):
+                query = RecruitmentResult.objects.filter(
+                    recruitment__year=year,
+                    recruitment__field_of_study=field,
+                    result="signed"
+                ).aggregate(Min('points'))['points__min']
+                result[field.name] = query if query else -1
+                print(query)
+
+            return Response(
+                {k: v for k, v in sorted(
+                    result.items(), key=lambda item: item[1],
+                    reverse=True if mode == "top" else False)[:n]})
+        except Exception as e:
+            print(e)
+            return Response(status=status.HTTP_400_BAD_REQUEST)

--- a/backend/views.py
+++ b/backend/views.py
@@ -682,7 +682,7 @@ class FacultyPopularity(APIView):
         except Exception as e:
             print(e)
             return Response(status=status.HTTP_400_BAD_REQUEST)
-          
+
 
 class FacultyThreshold(APIView):
     permission_classes = (IsAuthenticated,)


### PR DESCRIPTION
Dodałem endpoint, który zwraca nam n kierunków z największym/najmniejszym progiem

Adres: `/api/backend/faculty_threshold/{mode}/{degree}/{n}/{year}/`
Gdzie
mode to `top` albo `bot` (w zależności, które kierunki chcemy dostać)
degree to stopień studiów
n to ile top kierunków zwrócić
year z którego roku brać dane
Endpoint zwraca słownik w odpowiedniej kolejności, gdzie danemu kierunkowi przypisany jest próg w danym roku (jeżeli nie ma danych to zwróci -1).

Przykład:
`/api/backend/faculty_threshold/top/1/5/2020`
```
{
  "Informatyka": 803,
  "Elektronika": 668,
  "Fizyka": 530,
  "Zarządzanie": 455,
  "Automatyka": 257
}
```