### PR TITLE
CHA-55 Added endpoint

### DIFF
--- a/backend/urls.py
+++ b/backend/urls.py
@@ -12,7 +12,7 @@ from backend.views import (ActualFacultyThreshold, AddFacultyView,
                            RecruitmentResultOverviewListView,
                            RecruitmentStatusAggregateListView,
                            StatusDistributionView, UploadFieldsOfStudyView,
-                           UploadView)
+                           UploadView, GetMostLaureate)
 
 app_name = 'backend'
 
@@ -75,4 +75,6 @@ urlpatterns = [
         r'&cycle=(?P<cycle>.+)$',
         RecruitmentStatusAggregateListView.as_view(),
         name='actual_recruitment'),
+    path('laureate_stats/<int:n>/<int:year>',
+         GetMostLaureate.as_view(), name="laureate_stats")
 ]

--- a/backend/urls.py
+++ b/backend/urls.py
@@ -77,7 +77,7 @@ urlpatterns = [
         RecruitmentStatusAggregateListView.as_view(),
         name='actual_recruitment'),
     path('laureate_stats/<int:n>/<int:year>',
-         GetMostLaureate.as_view(), name="laureate_stats")
+         GetMostLaureate.as_view(), name="laureate_stats"),
     path('faculty_popularity/<str:pop_type>/<str:degree>/<int:n>/<int:year>/',
          FacultyPopularity.as_view(), name="faculty_popularity"),
 ]

--- a/backend/urls.py
+++ b/backend/urls.py
@@ -4,7 +4,7 @@ from backend.views import (ActualFacultyThreshold, AddFacultyView,
                            AddFieldOfStudy, AvgAndMedOfFields, CompareFields,
                            FieldOfStudyCandidatesPerPlaceListView,
                            FieldOfStudyContestLaureatesCountView, GetBasicData,
-                           GetFacultiesView, GetFieldsOfStudy,
+                           GetFacultiesView, GetFieldsOfStudy, GetMostLaureate,
                            GetThresholdOnField, LaureatesOnFOFSView,
                            RecruitmentResultFacultiesListView,
                            RecruitmentResultFieldsOfStudyListView,
@@ -12,7 +12,7 @@ from backend.views import (ActualFacultyThreshold, AddFacultyView,
                            RecruitmentResultOverviewListView,
                            RecruitmentStatusAggregateListView,
                            StatusDistributionView, UploadFieldsOfStudyView,
-                           UploadView, GetMostLaureate)
+                           UploadView)
 
 app_name = 'backend'
 

--- a/backend/views.py
+++ b/backend/views.py
@@ -657,7 +657,7 @@ class GetMostLaureate(APIView):
             print(e)
             return Response(status=status.HTTP_400_BAD_REQUEST)
 
-          
+
 class FacultyPopularity(APIView):
     permission_classes = (IsAuthenticated,)
 

--- a/backend/views.py
+++ b/backend/views.py
@@ -633,3 +633,26 @@ class ActualFacultyThreshold(APIView):
         except Exception as e:
             print(e)
             return Response(status=status.HTTP_503_SERVICE_UNAVAILABLE)
+
+
+class GetMostLaureate(APIView):
+    permission_classes = (IsAuthenticated,)
+
+    def get(self, request: Request, n: int, year: int) -> Response:
+        try:
+            result: Dict[str, float] = {}
+            for field in FieldOfStudy.objects.filter(degree="1"):
+                query = RecruitmentResult.objects.filter(
+                    recruitment__year=year,
+                    recruitment__field_of_study=field,
+                    result="signed",
+                    student__contest__isnull=False
+                )
+                result[field.name] = len(query)
+            return Response(
+                {k: v for k, v in sorted(
+                    result.items(), key=lambda item: item[1],
+                    reverse=True)[:n]})
+        except Exception as e:
+            print(e)
+            return Response(status=status.HTTP_400_BAD_REQUEST)


### PR DESCRIPTION
Dodałem endpoint, który zwraca nam n kierunków z największą liczbą laureatów w danym roku. Z założenia jest to pierwszy stopień. 

Adres: /api/backend/laureate_stats/<int:n>/<int:year>
Gdzie
n to ile top kierunków zwrócić
year z którego roku brać dane

Endpoint zwraca słownik w odpowiedniej kolejności, gdzie danemu kierunkowi przypisany jest liczba laureatów w danym roku.

Przykład:
/api/backend/laureate_stats/5/2020

{
  "Informatyka": 12,
  "Elektronika": 9,
  "Fizyka": 7,
  "Zarządzanie": 7,
  "Automatyka": 3
}