### PR TITLE
Feature/cha 115 add year to endpoints

### DIFF
--- a/backend/urls.py
+++ b/backend/urls.py
@@ -84,10 +84,16 @@ urlpatterns = [
             CompareFields.as_view(), name='compare_fields'),
     re_path(r'^aam/(?P<degree>.+)/(?P<faculty_year_list>.+)/$',
             AvgAndMedOfFields.as_view(), name='get_avg_and_med_of_fileds'),
+
     path(
         r'actual_recruitment_faculty_threshold/faculty=<faculty>'
         r'&cycle=<degree>/',
         ActualFacultyThreshold.as_view(), name='actual_threshold'),
+    path(
+        r'actual_recruitment_faculty_threshold/faculty=<faculty>'
+        r'&cycle=<degree>/<int:year>/',
+        ActualFacultyThreshold.as_view(), name='actual_threshold'),
+
     re_path(
         r'^actual_recruitment_faculty_aggregation/faculty=(?P<faculty>.+)'
         r'&cycle=(?P<cycle>.+)$',

--- a/backend/views.py
+++ b/backend/views.py
@@ -515,7 +515,8 @@ class LaureatesOnFOFSView(APIView):
     def get(self, request: Request, year: int = None,
             faculty: str = None) -> Response:
         try:
-            last_year = (year or
+            last_year = (
+                year or
                 Recruitment.objects.aggregate(Max('year'))["year__max"])
             if faculty:
                 tmp = list(RecruitmentResult.objects.

--- a/backend/views.py
+++ b/backend/views.py
@@ -735,8 +735,12 @@ class AvgAndMedOfFields(APIView):
 class ActualFacultyThreshold(APIView):
     permission_classes = (IsAuthenticated, )
 
-    def get(self, request: Request, faculty: str, degree: str) -> Response:
+    def get(self, request: Request, faculty: str, degree: str,
+            year: int = None) -> Response:
         try:
+            year = year or (
+                Recruitment.objects.aggregate(Max('year'))["year__max"])
+
             faculty_obj = Faculty.objects.get(name=faculty)
             # TODO change after models changes
             result: Dict[str, List[float]] = {}
@@ -747,8 +751,7 @@ class ActualFacultyThreshold(APIView):
                 for cycle in range(5):
                     recruitment = Recruitment.objects.filter(
                         field_of_study=field, round=cycle,
-                        year=Recruitment.objects.aggregate(
-                            Max('year'))["year__max"])
+                        year=year)
                     recruitment_results = RecruitmentResult.objects.filter(
                         recruitment__in=recruitment, result='signed')
                     threshold = recruitment_results.aggregate(

--- a/backend/views.py
+++ b/backend/views.py
@@ -515,7 +515,8 @@ class LaureatesOnFOFSView(APIView):
     def get(self, request: Request, year: int = None,
             faculty: str = None) -> Response:
         try:
-            last_year = Recruitment.objects.aggregate(Max('year'))["year__max"]
+            last_year = (year or
+                Recruitment.objects.aggregate(Max('year'))["year__max"])
             if faculty:
                 tmp = list(RecruitmentResult.objects.
                            filter(recruitment__year=(year or last_year)).


### PR DESCRIPTION
Widzę tylko 2 endpointy, do których dodałem możliwość podania roku.

- `api/backend/laureates-on-fofs/faculty/year/`
- `actual_recruitment_faculty_threshold/faculty=faculty&cycle=cycle/year/`

Jak jeszcze coś będzie do dopisania to poprawię