### PR TITLE
Feature/cha 127 same year field conversion

### DIFF
--- a/backend/urls.py
+++ b/backend/urls.py
@@ -145,7 +145,7 @@ urlpatterns = [
          FacultyPopularity.as_view(), name="faculty_popularity"),
     path('changes_after_cycle/<faculty>/<field_of_study>/<degree>/<year>/',
          ChangesAfterCycle.as_view(), name="changes_after_cycle"),
-    
+
     path('same-year-field-conversion/<int:year>/<faculty>/<field_of_study>/',
          SameYearFieldConversion.as_view(), name='same-year-field-conversion'),
     path('same-year-field-conversion/<int:year>/<faculty>/<field_of_study>/'

--- a/backend/urls.py
+++ b/backend/urls.py
@@ -16,7 +16,7 @@ from backend.views import (ActualFacultyThreshold, AddFacultyView,
                            RecruitmentResultListView,
                            RecruitmentResultOverviewListView,
                            RecruitmentStatusAggregateListView,
-                           RecruitmentYears,
+                           RecruitmentYears, SameYearFieldConversion,
                            StatusDistributionOverTheYearsView,
                            StatusDistributionView, UploadFieldsOfStudyView,
                            UploadView)
@@ -145,4 +145,10 @@ urlpatterns = [
          FacultyPopularity.as_view(), name="faculty_popularity"),
     path('changes_after_cycle/<faculty>/<field_of_study>/<degree>/<year>/',
          ChangesAfterCycle.as_view(), name="changes_after_cycle"),
+    
+    path('same-year-field-conversion/<int:year>/<faculty>/<field_of_study>/',
+         SameYearFieldConversion.as_view(), name='same-year-field-conversion'),
+    path('same-year-field-conversion/<int:year>/<faculty>/<field_of_study>/'
+         '<type>/<degree>/',
+         SameYearFieldConversion.as_view(), name='same-year-field-conversion'),
 ]

--- a/backend/views.py
+++ b/backend/views.py
@@ -1057,8 +1057,8 @@ class SameYearFieldConversion(APIView):
                     round = rr.recruitment.round
                     student = rr.student
                     other_rrs = (
-                        student.recruitmentresult__set
-                        # nie wiem czy potrzebne 
+                        student.recruitmentresult_set
+                        # nie wiem czy potrzebne
                         # .filter(result__in=["rejected", "unregistered"])
                         .filter(recruitment__year=year)
                         # nie wiem czy ma być mniejsze czy n-1
@@ -1066,7 +1066,8 @@ class SameYearFieldConversion(APIView):
                     )
 
                     for other_rr in other_rrs:
-                        other_faculty = other_rr.recruitment.field_of_study.faculty.name
+                        other_faculty = (
+                            other_rr.recruitment.field_of_study.faculty.name)
                         other_fof = other_rr.recruitment.field_of_study.name
                         name = other_faculty + other_fof
                         if round not in result:

--- a/backend/views.py
+++ b/backend/views.py
@@ -1014,3 +1014,75 @@ class ChangesAfterCycle(APIView):
                 {"problem": str(e)},
                 status=status.HTTP_400_BAD_REQUEST
             )
+
+
+class SameYearFieldConversion(APIView):
+    permission_classes = (IsAuthenticated,)
+
+    def get(self, request: Request,
+            year: int = None,
+            faculty: str = None,
+            field_of_study: str = None,
+            type: str = None,
+            degree: str = None) -> Response:
+
+        try:
+            year = year or (
+                Recruitment.objects.aggregate(Max('year'))["year__max"])
+
+            rrs = (
+                RecruitmentResult.objects
+                .filter(result__in=["accepted", "signed"])
+                .filter(recruitment__year=year)
+                .filter(
+                    recruitment__field_of_study__faculty__name__iexact=faculty)
+                .filter(
+                    recruitment__field_of_study__name__iexact=field_of_study)
+            )
+
+            if type:
+                rrs = rrs.filter(
+                    recruitment__field_of_study__type=type)
+            if degree:
+                rrs = rrs.filter(
+                    recruitment__field_of_study__degree=degree)
+
+            if type:
+                rrs = rrs.filter(
+                    recruitment__field_of_study__type=type)
+
+            result: Dict[Any, Any] = {}
+            for rr in rrs:
+                try:
+                    round = rr.recruitment.round
+                    student = rr.student
+                    other_rrs = (
+                        student.recruitmentresult__set
+                        # nie wiem czy potrzebne 
+                        # .filter(result__in=["rejected", "unregistered"])
+                        .filter(recruitment__year=year)
+                        # nie wiem czy ma być mniejsze czy n-1
+                        .filter(recruitment__round__lt=round)
+                    )
+
+                    for other_rr in other_rrs:
+                        other_faculty = other_rr.recruitment.field_of_study.faculty.name
+                        other_fof = other_rr.recruitment.field_of_study.name
+                        name = other_faculty + other_fof
+                        if round not in result:
+                            result[round] = {}
+                        if name not in result[round]:
+                            result[round][name] = 0
+
+                        result[round][name] += 1
+
+                except Exception as e:
+                    print(e)
+
+            return Response(result, status=status.HTTP_200_OK)
+
+        except Exception as e:
+            return Response(
+                {"problem": str(e)},
+                status=status.HTTP_503_SERVICE_UNAVAILABLE
+            )

--- a/backend/views.py
+++ b/backend/views.py
@@ -1047,10 +1047,6 @@ class SameYearFieldConversion(APIView):
                 rrs = rrs.filter(
                     recruitment__field_of_study__degree=degree)
 
-            if type:
-                rrs = rrs.filter(
-                    recruitment__field_of_study__type=type)
-
             result: Dict[Any, Any] = {}
             for rr in rrs:
                 try:
@@ -1069,7 +1065,7 @@ class SameYearFieldConversion(APIView):
                         other_faculty = (
                             other_rr.recruitment.field_of_study.faculty.name)
                         other_fof = other_rr.recruitment.field_of_study.name
-                        name = other_faculty + other_fof
+                        name = other_faculty + ";" + other_fof
                         if round not in result:
                             result[round] = {}
                         if name not in result[round]:


### PR DESCRIPTION
Zrobienie tego co miało być pierwotnie w CHA-108

Endpoint do informacji z jakich kierunków rezygnują osoby, aby przejść na nasz kierunek, z podziałem na cykle.

Ale chyba generator nie jest tak zaawansowany, żeby coś sensownego było zwracane :(

Teraz idąc pod adresy:
`api/backend/same-year-field-conversion/year/faculty/fof/`
`api/backend/same-year-field-conversion/year/faculty/fof/type/degree/`
otrzymamy dane po odpowiedniej filtracji

Odpowiedź jest podzielona na 2 stopnie zagnieżdżenia:
- cykl rekrutacyjny
- wydział;kierunek - nazwy rozdzielone średnikiem

Wzór JSONa:
```js
{
  cykl1: {
    kierunek1: liczba1,
    kierunek2: liczba2,
    ....
  },
  cykl2: {
    ...
  },
  ...
}
```
